### PR TITLE
Add `future` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lxml
+future

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="galaxyxml",
         description='Galaxy XML generation library',
         author='Eric Rasche',
         author_email='esr@tamu.edu',
-        install_requires=['lxml'],
+        install_requires=['lxml', 'future'],
         packages=["galaxyxml", "galaxyxml.tool", "galaxyxml.tool.parameters"],
         classifiers=[
             'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Incompatible with Python 2 without `future` module
