### PR TITLE
Add method to add comment(s) to the generated xml

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -59,5 +59,7 @@ tool.outputs = outputs
 tool.help = 'HI'
 tool.configfiles = configfiles
 
+tool.add_comment("This tool descriptor has been generated using galaxyxml.")
+
 print(tool.export().decode('utf-8'))
 

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <tool id="se.lu.mbioekol.mbio-serv2.aragorn" name="aragorn" version="1.2.36">
+  <!--This tool descriptor has been generated using galaxyxml.-->
   <description>Aragorn is a tRNA finder</description>
   <configfiles>
     <configfile name="testing"><![CDATA[Hello <> World]]></configfile>

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -49,6 +49,10 @@ class Tool(GalaxyXML):
         description_node = etree.SubElement(self.root, 'description')
         description_node.text = description
 
+    def add_comment(self, comment_txt):
+        comment = etree.Comment(comment_txt)
+        self.root.insert(0, comment)
+
     def append_version_command(self):
         version_command = etree.SubElement(self.root, 'version_command')
         try:


### PR DESCRIPTION
Dear Eric,

Here is a pull request to add a method to be able to comment the xml generated via galaxyxml. For instance, this can be pretty useful to keep tracks on the version of galaxyxml used for the generation.

Thank you,
Kenzo