### PR TITLE
Add more Galaxy xml tags

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -80,9 +80,14 @@ configfiles.append(gxtp.Configfile(
 configfiles.append(gxtp.ConfigfileDefaultInputs(name="inputs"))
 
 # Outputs
-param = gxtp.OutputParameter('output', format="tabular", num_dashes=1)
+param = gxtp.OutputData('output', format="tabular", num_dashes=1)
 param.space_between_arg = ' '
 outputs.append(param)
+# Collection
+collection = gxtp.OutputCollection('supercollection', label='a small label')
+discover = gxtp.DiscoverDatasets("(?P&lt;designation&gt;.+)\.pdf.fasta", format='fasta')
+collection.append(discover)
+outputs.append(collection)
 
 tool.inputs = inputs
 tool.outputs = outputs

--- a/examples/example.py
+++ b/examples/example.py
@@ -9,6 +9,12 @@ tool = gxt.Tool("aragorn", 'se.lu.mbioekol.mbio-serv2.aragorn',
 inputs = gxtp.Inputs()
 outputs = gxtp.Outputs()
 
+# Add requirements
+requirements = gxtp.Requirements()
+requirements.append(gxtp.Requirement('package', 'samtools', version='1.0.0'))
+requirements.append(gxtp.Container('docker', 'one_super_image'))
+tool.requirements = requirements
+
 # A parameter
 param = gxtp.BooleanParam('flag', label='Flag label', help='Flag help', num_dashes=1)
 # Yes I know this is rubbish. Please make a PR!!

--- a/examples/example.py
+++ b/examples/example.py
@@ -22,11 +22,13 @@ param.space_between_arg = ' '
 inputs.append(param)
 
 
-# A float
+# A float in a section
+section = gxtp.Section('float_section', 'Float section')
 param = gxtp.FloatParam('float', label='Float label',
                         help='Float help', value=0, num_dashes=1)
 param.space_between_arg = ' '
-inputs.append(param)
+section.append(param)
+inputs.append(section)
 
 # A conditional
 param = gxtp.Conditional('cond', label='Conditional')

--- a/examples/example.py
+++ b/examples/example.py
@@ -22,7 +22,7 @@ param = gxtp.FloatParam('float', label='Float label',
 param.space_between_arg = ' '
 inputs.append(param)
 
-
+# A conditional
 param = gxtp.Conditional('cond', label='Conditional')
 param.append(gxtp.SelectParam('Select', options={'hi': '1', 'bye': '2'}))
 when_a = gxtp.When(value='hi')
@@ -32,7 +32,7 @@ param.append(when_a)
 param.append(when_b)
 inputs.append(param)
 
-
+# Integer parameters
 param_min = gxtp.IntegerParam('int_min',
                               label='int_min label',
                               help='int_min help', value=0, num_dashes=1)
@@ -50,6 +50,18 @@ param_max.space_between_arg = ' '
 inputs.append(param_min)
 inputs.append(param_max)
 inputs.append(posint)
+
+# Add Select with options from_file with columns and filter
+param = gxtp.SelectParam('select_local')
+options = gxtp.Options(from_file='loc_file.loc')
+column_a = gxtp.Column('name', 0)
+options.append(column_a)
+column_b = gxtp.Column('value', 1)
+options.append(column_b)
+filter_a = gxtp.Filter('sort_by', name='sorted', column='1')
+options.append(filter_a)
+param.append(options)
+inputs.append(param)
 
 # Configfiles
 configfiles = gxtp.Configfiles()

--- a/examples/example.py
+++ b/examples/example.py
@@ -87,6 +87,17 @@ tool.outputs = outputs
 tool.help = 'HI'
 tool.configfiles = configfiles
 
+# Add Tests sections
+tool.tests = gxtp.Tests()
+test_a = gxtp.Test()
+param = gxtp.TestParam('float', value=5.4)
+test_a.append(param)
+test_out = gxtp.TestOutput(name='output', value='file.out')
+test_a.append(test_out)
+tool.tests.append(test_a)
+
+
+# Add comment to the wrapper
 tool.add_comment("This tool descriptor has been generated using galaxyxml.")
 
 print(tool.export().decode('utf-8'))

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -2,6 +2,10 @@
 <tool id="se.lu.mbioekol.mbio-serv2.aragorn" name="aragorn" version="1.2.36">
   <!--This tool descriptor has been generated using galaxyxml.-->
   <description>Aragorn is a tRNA finder</description>
+  <requirements>
+    <requirement type="package" version="1.0.0">samtools</requirement>
+    <container type="docker">one_super_image</container>
+  </requirements>
   <configfiles>
     <configfile name="testing"><![CDATA[Hello <> World]]></configfile>
     <inputs name="inputs"/>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -27,7 +27,10 @@ select_local $select_local]]></command>
       <param argument="-float" help="Float help" label="Float label" name="float" type="float" value="0"/>
     </section>
     <conditional argument="cond" label="Conditional" name="cond">
-      <param argument="Select" label="Author did not provide help for this parameter... " name="Select" type="select"/>
+      <param argument="Select" label="Author did not provide help for this parameter... " name="Select" type="select">
+        <option value="bye">2</option>
+        <option value="hi">1</option>
+      </param>
       <when value="hi"/>
       <when value="bye">
         <param argument="-some_int" label="Advanced value" name="some_int" type="integer" value="0"/>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -46,5 +46,11 @@ select_local $select_local
   <outputs>
     <data format="tabular" hidden="false" name="output"/>
   </outputs>
+  <tests>
+    <test>
+      <param name="float" value="5.4"/>
+      <output name="output" value="file.out"/>
+    </test>
+  </tests>
   <help><![CDATA[HI]]></help>
 </tool>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <tool id="se.lu.mbioekol.mbio-serv2.aragorn" name="aragorn" version="1.2.36">
   <!--This tool descriptor has been generated using galaxyxml.-->
   <description>Aragorn is a tRNA finder</description>
@@ -16,15 +15,13 @@ cond $cond
 -i$int_min,$int_max
 
 $posint
+select_local $select_local
 -output $output]]></command>
   <inputs>
     <param argument="-flag" checked="false" help="Flag help" label="Flag label" name="flag" type="boolean" truevalue="-flag" falsevalue=""/>
     <param argument="-float" help="Float help" label="Float label" name="float" type="float" value="0"/>
     <conditional argument="cond" label="Conditional" name="cond">
-      <param argument="Select" label="Author did not provide help for this parameter... " name="Select" type="select">
-        <option value="bye">2</option>
-        <option value="hi">1</option>
-      </param>
+      <param argument="Select" label="Author did not provide help for this parameter... " name="Select" type="select"/>
       <when value="hi"/>
       <when value="bye">
         <param argument="-some_int" label="Advanced value" name="some_int" type="integer" value="0"/>
@@ -33,9 +30,17 @@ $posint
     <param argument="-int_min" help="int_min help" label="int_min label" name="int_min" type="integer" value="0"/>
     <param argument="-int_max" help="int_max help" label="int_max label" name="int_max" type="integer" value="0"/>
     <param help="posinthelp" label="posint label" name="posint" type="integer" value="0"/>
+    <param argument="select_local" label="Author did not provide help for this parameter... " name="select_local" type="select">
+      <options from_file="loc_file.loc">
+        <column index="0" name="name"/>
+        <column index="1" name="value"/>
+        <filter column="1" name="sorted" type="sort_by"/>
+      </options>
+    </param>
   </inputs>
   <outputs>
     <data format="tabular" hidden="false" name="output"/>
   </outputs>
   <help><![CDATA[HI]]></help>
 </tool>
+

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -20,8 +20,7 @@ cond $cond
 -i$int_min,$int_max
 
 $posint
-select_local $select_local
--output $output]]></command>
+select_local $select_local]]></command>
   <inputs>
     <param argument="-flag" checked="false" help="Flag help" label="Flag label" name="flag" type="boolean" truevalue="-flag" falsevalue=""/>
     <section name="float_section" title="Float section">
@@ -47,6 +46,9 @@ select_local $select_local
   </inputs>
   <outputs>
     <data format="tabular" hidden="false" name="output"/>
+    <collection label="a small label" name="supercollection">
+      <discover_datasets format="fasta" pattern="(?P&amp;lt;designation&amp;gt;.+)\.pdf.fasta"/>
+    </collection>
   </outputs>
   <tests>
     <test>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <tool id="se.lu.mbioekol.mbio-serv2.aragorn" name="aragorn" version="1.2.36">
   <!--This tool descriptor has been generated using galaxyxml.-->
   <description>Aragorn is a tRNA finder</description>
@@ -43,4 +44,3 @@ select_local $select_local
   </outputs>
   <help><![CDATA[HI]]></help>
 </tool>
-

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -15,7 +15,7 @@
   </stdio>
   <version_command>aragorn.exe --version</version_command>
   <command><![CDATA[aragorn.exe $flag
--float $float
+float_section $float_section
 cond $cond
 -i$int_min,$int_max
 
@@ -24,7 +24,9 @@ select_local $select_local
 -output $output]]></command>
   <inputs>
     <param argument="-flag" checked="false" help="Flag help" label="Flag label" name="flag" type="boolean" truevalue="-flag" falsevalue=""/>
-    <param argument="-float" help="Float help" label="Float label" name="float" type="float" value="0"/>
+    <section name="float_section" title="Float section">
+      <param argument="-float" help="Float help" label="Float label" name="float" type="float" value="0"/>
+    </section>
     <conditional argument="cond" label="Conditional" name="cond">
       <param argument="Select" label="Author did not provide help for this parameter... " name="Select" type="select"/>
       <when value="hi"/>

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -139,6 +139,11 @@ class Tool(GalaxyXML):
         except:
             pass
 
+        try:
+            export_xml.append(export_xml.tests)
+        except:
+            pass
+
         help_element = etree.SubElement(export_xml.root, 'help')
         help_element.text = etree.CDATA(export_xml.help)
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -425,6 +425,7 @@ class SelectParam(Param):
             if default not in options:
                 raise Exception("Specified a default that isn't in options")
 
+        if options:
             for k, v in list(sorted(options.items())):
                 selected = (k == default)
                 self.append(SelectOption(k, v, selected=selected))

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -403,12 +403,13 @@ class SelectParam(Param):
             if default not in options:
                 raise Exception("Specified a default that isn't in options")
 
-        for k, v in list(sorted(options.items())):
-            selected = (k == default)
-            self.append(SelectOption(k, v, selected=selected))
+            for k, v in list(sorted(options.items())):
+                selected = (k == default)
+                self.append(SelectOption(k, v, selected=selected))
 
     def acceptable_child(self, child):
-        return issubclass(type(child), SelectOption)
+        return issubclass(type(child), SelectOption) \
+                or issubclass(type(child), Options)
 
 
 class SelectOption(InputParameter):
@@ -424,6 +425,36 @@ class SelectOption(InputParameter):
 
         super(SelectOption, self).__init__(None, **passed_kwargs)
         self.node.text = str(text)
+
+
+class Options(InputParameter):
+    name = 'options'
+
+    def __init__(self, from_dataset=None, from_file=None, from_data_table=None,
+                 from_parameter=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(Options, self).__init__(None, **params)
+
+    def acceptable_child(self, child):
+        return issubclass(type(child), Column) or issubclass(type(child), Filter)
+
+
+class Column(InputParameter):
+    name = 'column'
+
+    def __init__(self, name, index, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(Column, self).__init__(**params)
+
+
+class Filter(InputParameter):
+    name = 'filter'
+
+    def __init__(self, type, column=None, name=None, ref=None, key=None,
+                 multiple=None, separator=None, keep=None, value=None,
+                 ref_attribute=None, index=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(Filter, self).__init__(**params)
 
 
 class ValidatorParam(InputParameter):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -557,6 +557,38 @@ class ChangeFormatWhen(XMLParam):
         return False
 
 
+class Tests(XMLParam):
+    name = 'tests'
+
+    def acceptable_child(self, child):
+        return issubclass(type(child), Test)
+
+
+class Test(XMLParam):
+    name = 'test'
+
+    def acceptable_child(self, child):
+        return isinstance(child, TestParam) or isinstance(child, TestOutput)
+
+
+class TestParam(XMLParam):
+    name = 'param'
+
+    def __init__(self, name, value=None, ftype=None, dbkey=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(TestParam, self).__init__(**params)
+
+
+class TestOutput(XMLParam):
+    name = 'output'
+
+    def __init__(self, name=None, file=None, ftype=None, sort=None, value=None,
+                 md5=None, checksum=None, compare=None, lines_diff=None,
+                 delta=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(TestOutput, self).__init__(**params)
+
+
 class Citations(XMLParam):
     name = 'citations'
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -493,10 +493,10 @@ class Outputs(XMLParam):
     name = 'outputs'
 
     def acceptable_child(self, child):
-        return issubclass(type(child), OutputParameter)
+        return isinstance(child, OutputData) or isinstance(child, OutputCollection)
 
 
-class OutputParameter(XMLParam):
+class OutputData(XMLParam):
     """Copypasta of InputParameter, needs work
     """
     name = 'data'
@@ -514,7 +514,7 @@ class OutputParameter(XMLParam):
         self.space_between_arg = " "
         params = Util.clean_kwargs(locals().copy())
 
-        super(OutputParameter, self).__init__(**params)
+        super(OutputData, self).__init__(**params)
 
     def command_line(self):
         if hasattr(self, 'command_line_override'):
@@ -566,6 +566,28 @@ class ChangeFormatWhen(XMLParam):
 
     def acceptable_child(self, child):
         return False
+
+
+class OutputCollection(XMLParam):
+    name = 'collection'
+
+    def __init__(self, name, type=None, label=None, format_source=None,
+                 type_source=None, structured_like=None, inherit_format=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(OutputCollection, self).__init__(**params)
+
+    def acceptable_child(self, child):
+        return isinstance(child, OutputData) or isinstance(child, OutputFilter) \
+            or isinstance(child, DiscoverDatasets)
+
+
+class DiscoverDatasets(XMLParam):
+    name = 'discover_datasets'
+
+    def __init__(self, pattern, directory=None, format=None, ext=None,
+                 visible=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(DiscoverDatasets, self).__init__(**params)
 
 
 class Tests(XMLParam):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -129,7 +129,7 @@ class Requirements(XMLParam):
     # This bodes to be an issue -__-
 
     def acceptable_child(self, child):
-        return issubclass(type(child), Requirement)
+        return issubclass(type(child), Requirement) or issubclass(type(child), Container)
 
 
 class Requirement(XMLParam):
@@ -141,6 +141,17 @@ class Requirement(XMLParam):
         passed_kwargs['version'] = params['version']
         passed_kwargs['type'] = params['type']
         super(Requirement, self).__init__(**passed_kwargs)
+        self.node.text = str(value)
+
+
+class Container(XMLParam):
+    name = 'container'
+
+    def __init__(self, type, value, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        passed_kwargs = {}
+        passed_kwargs['type'] = params['type']
+        super(Container, self).__init__(**passed_kwargs)
         self.node.text = str(value)
 
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -267,6 +267,17 @@ class InputParameter(XMLParam):
         return flag + self.mako_identifier
 
 
+class Section(InputParameter):
+    name = 'section'
+
+    def __init__(self, name, title, expanded=None, help=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(Section, self).__init__(**params)
+
+    def acceptable_child(self, child):
+        return issubclass(type(child), InputParameter)
+
+
 class Repeat(InputParameter):
     name = 'repeat'
 


### PR DESCRIPTION
Hi Eric,

I have added few new classes of tags that were not implemented in the library: 
* `<options>` with `<filter>` and `<column>`
* `<container>` for `<requirements>`
* Started to add `<tests>` section
* `<section>` in `<inputs>`
* `<collection>` with `<discover_datasets>` in `<outputs>`

I did not work on the link between parameters and command yet, but I need these classes to improve import from an existing XML to try to cover all possibilities. Thanks!