### PR TITLE
added spaces to textparam command line in case of spaces

### DIFF
--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -379,6 +379,15 @@ class TextParam(Param):
         params = Util.clean_kwargs(locals().copy())
         super(TextParam, self).__init__(**params)
 
+    def command_line_actual(self): # quote in case of spaces
+        try:
+            return self.command_line_override
+        except Exception:
+            if self.positional:
+                return self.mako_name()
+            else:
+                return '%s%s"%s"' % (self.flag(), self.space_between_arg, self.mako_name())
+
 
 class _NumericParam(Param):
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -379,7 +379,7 @@ class TextParam(Param):
         params = Util.clean_kwargs(locals().copy())
         super(TextParam, self).__init__(**params)
 
-    def command_line_actual(self): # quote in case of spaces
+    def command_line_actual(self): 
         try:
             return self.command_line_override
         except Exception:


### PR DESCRIPTION
Textparam values are likely to need quoting if they contain spaces.

Easy enough to override but this patch may save someone else the head scratching needed the first time it happens....

Thanks for the very useful package !