### PR TITLE
Add quotes to textparam command line - spaces may cause breakage...

### DIFF
--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -379,6 +379,15 @@ class TextParam(Param):
         params = Util.clean_kwargs(locals().copy())
         super(TextParam, self).__init__(**params)
 
+    def command_line_actual(self): # quote in case of spaces
+        try:
+            return self.command_line_override
+        except Exception:
+            if self.positional:
+                return self.mako_name()
+            else:
+                return '%s%s"%s"' % (self.flag(), self.space_between_arg, self.mako_name())
+
 
 class _NumericParam(Param):
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -386,7 +386,7 @@ class TextParam(Param):
             if self.positional:
                 return self.mako_name()
             else:
-                return f'{self.flag}{self.space_between_arg}"{self.mako_name()}"'
+                return f"{self.flag}{self.space_between_arg}'{self.mako_name()}'"
 
 
 class _NumericParam(Param):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -379,7 +379,7 @@ class TextParam(Param):
         params = Util.clean_kwargs(locals().copy())
         super(TextParam, self).__init__(**params)
 
-    def command_line_actual(self): 
+    def command_line_actual(self):
         try:
             return self.command_line_override
         except Exception:

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -386,7 +386,7 @@ class TextParam(Param):
             if self.positional:
                 return self.mako_name()
             else:
-                return '%s%s"%s"' % (self.flag(), self.space_between_arg, self.mako_name())
+                return f'{self.flag}{self.space_between_arg}"{self.mako_name()}"'
 
 
 class _NumericParam(Param):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -379,7 +379,7 @@ class TextParam(Param):
         params = Util.clean_kwargs(locals().copy())
         super(TextParam, self).__init__(**params)
 
-    def command_line_actual(self): # quote in case of spaces
+    def command_line_actual(self): 
         try:
             return self.command_line_override
         except Exception:


### PR DESCRIPTION
Add quotes to textparam command line. Without them things go pear shaped if there are spaces in the value being passed...