### PR TITLE
add command_line_override to tool class 

### DIFF
--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -15,10 +15,12 @@ class Tool(GalaxyXML):
 
     def __init__(self, name, id, version, description, executable, hidden=False,
                  tool_type=None, URL_method=None, workflow_compatible=True,
-                 interpreter=None, version_command='interpreter filename.exe --version'):
+                 interpreter=None, version_command='interpreter filename.exe --version',
+                 command_line_override=None):
 
         self.executable = executable
         self.interpreter = interpreter
+        self.command_line_override = command_line_override
         kwargs = {
             'name': name,
             'id': id,
@@ -103,16 +105,19 @@ class Tool(GalaxyXML):
         except Exception:
             pass
 
-        command_line = []
-        try:
-            command_line.append(export_xml.inputs.cli())
-        except Exception as e:
-            logger.warning(str(e))
+        if self.command_line_override != None:
+            command_line = self.command_line_override
+        else:
+            command_line = []
+            try:
+                command_line.append(export_xml.inputs.cli())
+            except Exception as e:
+                logger.warning(str(e))
 
-        try:
-            command_line.append(export_xml.outputs.cli())
-        except Exception:
-            pass
+            try:
+                command_line.append(export_xml.outputs.cli())
+            except Exception:
+                pass
 
         # Add stdio section
         stdio = etree.SubElement(export_xml.root, 'stdio')

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -29,7 +29,6 @@ class Tool(GalaxyXML):
         command_line_override=None,
     ):
 
-
         self.executable = executable
         self.interpreter = interpreter
         self.command_line_override = command_line_override
@@ -115,7 +114,7 @@ class Tool(GalaxyXML):
         except Exception:
             pass
 
-        if self.command_line_override != None:
+        if self.command_line_override:
             command_line = self.command_line_override
         else:
             command_line = []


### PR DESCRIPTION
See #1

This allows me to override at the level of the input and output command line to allow an application to generate correctly ordered positional parameters 