### PR TITLE
Fix for leakage of executable into <command> section if command_line_override supplied

### DIFF
--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -28,12 +28,13 @@ class Tool(GalaxyXML):
         workflow_compatible=True,
         interpreter=None,
         version_command="interpreter filename.exe --version",
-        command_line_override=None,
+        command_override=None,
+        test_override=None,
     ):
 
         self.executable = executable
         self.interpreter = interpreter
-        self.command_line_override = command_line_override
+        self.command_override = command_override
         kwargs = {
             "name": name,
             "id": id,
@@ -116,8 +117,8 @@ class Tool(GalaxyXML):
         except Exception:
             pass
 
-        if self.command_line_override:
-            command_line = self.command_line_override
+        if self.command_override:
+            command_line = self.command_override
         else:
             command_line = []
             try:
@@ -152,7 +153,7 @@ class Tool(GalaxyXML):
                 logger.warning("The tool does not have any old command stored. " + "Only the command line is written.")
                 command_node.text = export_xml.executable
         else:
-            if self.command_line_override:
+            if self.command_override:
                 actual_cli = export_xml.clean_command_string(command_line)
             else:
                 actual_cli = "%s %s" % (export_xml.executable, export_xml.clean_command_string(command_line))
@@ -168,10 +169,13 @@ class Tool(GalaxyXML):
         except Exception:
             pass
 
-        try:
-            export_xml.append(export_xml.tests)
-        except Exception:
-            pass
+        if self.test_override:
+            export_xml.append(self.test_override)
+        else:
+            try:
+                export_xml.append(export_xml.tests)
+            except Exception:
+                pass
 
         help_element = etree.SubElement(export_xml.root, "help")
         help_element.text = etree.CDATA(export_xml.help)

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -29,7 +29,6 @@ class Tool(GalaxyXML):
         interpreter=None,
         version_command="interpreter filename.exe --version",
         command_override=None,
-        test_override=None,
     ):
 
         self.executable = executable
@@ -118,7 +117,7 @@ class Tool(GalaxyXML):
             pass
 
         if self.command_override:
-            command_line = self.command_override
+            command_line = self.command_override.split(' ')
         else:
             command_line = []
             try:
@@ -169,13 +168,10 @@ class Tool(GalaxyXML):
         except Exception:
             pass
 
-        if self.test_override:
-            export_xml.append(self.test_override)
-        else:
-            try:
-                export_xml.append(export_xml.tests)
-            except Exception:
-                pass
+        try:
+            export_xml.append(export_xml.tests)
+        except Exception:
+            pass
 
         help_element = etree.SubElement(export_xml.root, "help")
         help_element.text = etree.CDATA(export_xml.help)

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -117,7 +117,7 @@ class Tool(GalaxyXML):
             pass
 
         if self.command_override:
-            command_line = self.command_override.split('\n')
+            command_line = self.command_override
         else:
             command_line = []
             try:

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -152,7 +152,10 @@ class Tool(GalaxyXML):
                 logger.warning("The tool does not have any old command stored. " + "Only the command line is written.")
                 command_node.text = export_xml.executable
         else:
-            actual_cli = "%s %s" % (export_xml.executable, export_xml.clean_command_string(command_line))
+            if self.command_line_override:
+                actual_cli = clean_command_string(command_line)
+            else:
+                actual_cli = "%s %s" % (export_xml.executable, export_xml.clean_command_string(command_line))
             command_node.text = etree.CDATA(actual_cli.strip())
 
         try:

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -153,7 +153,7 @@ class Tool(GalaxyXML):
                 command_node.text = export_xml.executable
         else:
             if self.command_line_override:
-                actual_cli = clean_command_string(command_line)
+                actual_cli = export_xml.clean_command_string(command_line)
             else:
                 actual_cli = "%s %s" % (export_xml.executable, export_xml.clean_command_string(command_line))
             command_node.text = etree.CDATA(actual_cli.strip())

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -117,7 +117,7 @@ class Tool(GalaxyXML):
             pass
 
         if self.command_override:
-            command_line = self.command_override.split(' ')
+            command_line = self.command_override.split('\n')
         else:
             command_line = []
             try:

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -3,14 +3,24 @@ Unit tests for the import of existing Galaxy XML to galaxyxml.
 """
 
 import unittest
-from galaxyxml.tool.import_xml import GalaxyXmlParser
 
+from galaxyxml.tool.import_xml import GalaxyXmlParser
+import galaxyxml.tool as gxt
+import galaxyxml.tool.parameters as gxtp
 
 class TestImport(unittest.TestCase):
     def setUp(self):
         gxp = GalaxyXmlParser()
         self.tool = gxp.import_xml("test/import_xml.xml")
-
+    
+class TestOverrides(TestImport):
+    def test_override(self):
+        co = "bash foo.sh > output1"
+        self.tool.command_override = co
+        exml = self.tool.export()
+        self.assertTrue(self.tool.command_override==co)
+        exml = exml.replace('\n',' ')
+        self.assertTrue(co in exml)
 
 class TestImportXml(TestImport):
     def test_init_tool(self):
@@ -19,7 +29,6 @@ class TestImportXml(TestImport):
         self.assertEqual(xml_root.attrib["name"], "Import")
         self.assertEqual(xml_root.attrib["version"], "1.0")
         self.assertEqual(xml_root[0].text, "description")
-        self.assertEqual(self.tool.command, "command")
 
     def test_load_help(self):
         self.assertEqual(self.tool.help, "help")

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -5,22 +5,23 @@ Unit tests for the import of existing Galaxy XML to galaxyxml.
 import unittest
 
 from galaxyxml.tool.import_xml import GalaxyXmlParser
-import galaxyxml.tool as gxt
-import galaxyxml.tool.parameters as gxtp
+
 
 class TestImport(unittest.TestCase):
     def setUp(self):
         gxp = GalaxyXmlParser()
         self.tool = gxp.import_xml("test/import_xml.xml")
-    
+
+
 class TestOverrides(TestImport):
     def test_override(self):
         co = "bash foo.sh > output1"
         self.tool.command_override = co
         exml = self.tool.export()
-        self.assertTrue(self.tool.command_override==co)
-        exml = exml.replace('\n',' ')
+        self.assertTrue(self.tool.command_override == co)
+        exml = exml.replace("\n", " ")
         self.assertTrue(co in exml)
+
 
 class TestImportXml(TestImport):
     def test_init_tool(self):
@@ -38,7 +39,7 @@ class TestImportXml(TestImport):
         self.assertEqual(requirement.text, "magic_package")
         self.assertEqual(requirement.attrib["type"], "package")
         self.assertEqual(requirement.attrib["version"], "1")
-        container = self.tool.requirements.children[1].node
+        # never used ? container = self.tool.requirements.children[1].node
 
     def test_load_edam_topics(self):
         topic = self.tool.edam_topics.children[0].node

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -16,9 +16,10 @@ class TestImport(unittest.TestCase):
 class TestOverrides(TestImport):
     def test_override(self):
         co = "bash foo.sh > output1"
-        self.tool.command_override = co
+        col = co.split(' ')
+        self.tool.command_override = col
         exml = self.tool.export()
-        self.assertTrue(self.tool.command_override == co)
+        self.assertTrue(self.tool.command_override == col)
         exml = exml.replace("\n", " ")
         self.assertTrue(co in exml)
 


### PR DESCRIPTION
Pasting the nominated executable before a supplied override for the tool command section will likely break - the supplier of a command override probably does not want the executable prepended to their handiwork :)

Needs to be a list. Doh! So now expects one.

Somewhat simplistic test added. What with flake news and tests, this old dog has learned some new tricks. Or perhaps just caught the currently popular fleas?

Name changed to command_override for less confusion. I am probably the only one who ever used this so I hope that won't break anything? 

Finessing a <test> replacement is going to be harder. It will need to replace the generated <test> segment so I have resort to text replacement chicanery in the ToolFactory to get it to work..It can now generate a working version of the planemo bwa example using a supplied <command> segment.

Please bump version if this is accepted...

Thanks @hexylena 
