### PR TITLE
Reorder export so it matches planemo lint expectations. Remove ftype from test output

### DIFF
--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -109,9 +109,14 @@ class Tool(GalaxyXML):
             export_xml.append(export_xml.requirements)
         except Exception:
             pass
-        # Add stdio section - TODO: make into an XMLParameter
-        stdio_element = etree.SubElement(export_xml.root, "stdio")
-        etree.SubElement(stdio_element, "exit_code", range="1:", level="fatal")
+        # Add stdio section - now an XMLParameter
+        try:
+            stdio_element = export_xml.stdios
+        except Exception:
+            stdio_element = None
+        if not stdio_element:
+            stdio_element = etree.SubElement(export_xml.root, "stdio")
+            etree.SubElement(stdio_element, "exit_code", range="1:", level="fatal")
         export_xml.append(stdio_element)
         # Append version command
         export_xml.append_version_command()

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -148,7 +148,7 @@ class Tool(GalaxyXML):
                 command_node.text = etree.CDATA(export_xml.command)
             else:
                 logger.warning(
-                    "The tool does not have any old command stored. " +
+                    "The tool does not have any old command stored. "
                     "Only the command line is written."
                 )
                 command_node.text = export_xml.executable

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -139,7 +139,7 @@ class Tool(GalaxyXML):
             else:
                 logger.warning(
                     "The tool does not have any old command stored. " + \
-                    "Only the command line is written."
+                      "Only the command line is written."
                 )
                 command_node.text = export_xml.executable
         else:

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -14,21 +14,23 @@ logger = logging.getLogger(__name__)
 
 
 class Tool(GalaxyXML):
+
     def __init__(
-            self,
-            name,
-            id,
-            version,
-            description,
-            executable,
-            hidden=False,
-            tool_type=None,
-            URL_method=None,
-            workflow_compatible=True,
-            interpreter=None,
-            version_command="interpreter filename.exe --version",
-            command_override=None,
+        self,
+        name,
+        id,
+        version,
+        description,
+        executable,
+        hidden=False,
+        tool_type=None,
+        URL_method=None,
+        workflow_compatible=True,
+        interpreter=None,
+        version_command="interpreter filename.exe --version",
+        command_override=None,
     ):
+
         self.executable = executable
         self.interpreter = interpreter
         self.command_override = command_override
@@ -52,9 +54,7 @@ class Tool(GalaxyXML):
 
         if tool_type is not None:
             if tool_type not in VALID_TOOL_TYPES:
-                raise Exception(
-                    "Tool type must be one of %s" % ",".join(VALID_TOOL_TYPES)
-                )
+                raise Exception("Tool type must be one of %s" % ",".join(VALID_TOOL_TYPES))
             else:
                 kwargs["tool_type"] = tool_type
 
@@ -62,9 +62,7 @@ class Tool(GalaxyXML):
                     if URL_method in VALID_URL_METHODS:
                         kwargs["URL_method"] = URL_method
                     else:
-                        raise Exception(
-                            "URL_method must be one of %s" % ",".join(VALID_URL_METHODS)
-                        )
+                        raise Exception("URL_method must be one of %s" % ",".join(VALID_URL_METHODS))
 
         description_node = etree.SubElement(self.root, "description")
         description_node.text = description
@@ -94,21 +92,26 @@ class Tool(GalaxyXML):
 
         return "\n".join(clean)
 
+
     def export(self, keep_old_command=False): # noqa
         # see lib/galaxy/tool_util/linters/xml_order.py
         export_xml = copy.deepcopy(self)
+
         try:
             export_xml.append(export_xml.edam_operations)
         except Exception:
             pass
+
         try:
             export_xml.append(export_xml.edam_topics)
         except Exception:
             pass
+
         try:
             export_xml.append(export_xml.requirements)
         except Exception:
             pass
+
         # Add stdio section - now an XMLParameter
         try:
             stdio_element = export_xml.stdios
@@ -118,8 +121,10 @@ class Tool(GalaxyXML):
             stdio_element = etree.SubElement(export_xml.root, "stdio")
             etree.SubElement(stdio_element, "exit_code", range="1:", level="fatal")
         export_xml.append(stdio_element)
+
         # Append version command
         export_xml.append_version_command()
+
         if self.command_override:
             command_line = self.command_override
         else:
@@ -157,10 +162,12 @@ class Tool(GalaxyXML):
                 )
             command_node.text = etree.CDATA(actual_cli.strip())
         export_xml.append(command_node)
+
         try:
             export_xml.append(export_xml.configfiles)
         except Exception:
             pass
+
         try:
             export_xml.append(export_xml.inputs)
         except Exception:
@@ -169,15 +176,19 @@ class Tool(GalaxyXML):
             export_xml.append(export_xml.outputs)
         except Exception:
             pass
+
         try:
             export_xml.append(export_xml.tests)
         except Exception:
             pass
+
         help_element = etree.SubElement(export_xml.root, "help")
         help_element.text = etree.CDATA(export_xml.help)
         export_xml.append(help_element)
+
         try:
             export_xml.append(export_xml.citations)
         except Exception:
             pass
+
         return super(Tool, export_xml).export()

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -15,21 +15,20 @@ logger = logging.getLogger(__name__)
 
 class Tool(GalaxyXML):
     def __init__(
-        self,
-        name,
-        id,
-        version,
-        description,
-        executable,
-        hidden=False,
-        tool_type=None,
-        URL_method=None,
-        workflow_compatible=True,
-        interpreter=None,
-        version_command="interpreter filename.exe --version",
-        command_override=None,
+            self,
+            name,
+            id,
+            version,
+            description,
+            executable,
+            hidden=False,
+            tool_type=None,
+            URL_method=None,
+            workflow_compatible=True,
+            interpreter=None,
+            version_command="interpreter filename.exe --version",
+            command_override=None,
     ):
-
         self.executable = executable
         self.interpreter = interpreter
         self.command_override = command_override
@@ -95,8 +94,8 @@ class Tool(GalaxyXML):
 
         return "\n".join(clean)
 
-    def export(self, keep_old_command=False):
-        """see lib/galaxy/tool_util/linters/xml_order.py"""
+    def export(self, keep_old_command=False): # noqa
+        # see lib/galaxy/tool_util/linters/xml_order.py
         export_xml = copy.deepcopy(self)
         try:
             export_xml.append(export_xml.edam_operations)
@@ -124,7 +123,6 @@ class Tool(GalaxyXML):
                 command_line.append(export_xml.inputs.cli())
             except Exception as e:
                 logger.warning(str(e))
-
             try:
                 command_line.append(export_xml.outputs.cli())
             except Exception:
@@ -135,14 +133,13 @@ class Tool(GalaxyXML):
             command_kwargs["interpreter"] = export_xml.interpreter
         # Add command section
         command_node = etree.SubElement(export_xml.root, "command", **command_kwargs)
-
         if keep_old_command:
             if getattr(self, "command", None):
                 command_node.text = etree.CDATA(export_xml.command)
             else:
                 logger.warning(
-                    "The tool does not have any old command stored. "
-                    + "Only the command line is written."
+                    "The tool does not have any old command stored. " + \
+                    "Only the command line is written."
                 )
                 command_node.text = export_xml.executable
         else:

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -109,10 +109,10 @@ class Tool(GalaxyXML):
             export_xml.append(export_xml.requirements)
         except Exception:
             pass
-        # Add stdio section
-        stdio = etree.SubElement(export_xml.root, "stdio")
-        etree.SubElement(stdio, "exit_code", range="1:", level="fatal")
-        export_xml.append(stdio)
+        # Add stdio section - TODO: make into an XMLParameter
+        stdio_element = etree.SubElement(export_xml.root, "stdio")
+        etree.SubElement(stdio_element, "exit_code", range="1:", level="fatal")
+        export_xml.append(stdio_element)
         # Append version command
         export_xml.append_version_command()
         if self.command_override:
@@ -138,7 +138,7 @@ class Tool(GalaxyXML):
                 command_node.text = etree.CDATA(export_xml.command)
             else:
                 logger.warning(
-                    "The tool does not have any old command stored. " + \
+                    "The tool does not have any old command stored. " +
                     "Only the command line is written."
                 )
                 command_node.text = export_xml.executable

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 class Tool(GalaxyXML):
-
     def __init__(
         self,
         name,
@@ -54,7 +53,9 @@ class Tool(GalaxyXML):
 
         if tool_type is not None:
             if tool_type not in VALID_TOOL_TYPES:
-                raise Exception("Tool type must be one of %s" % ",".join(VALID_TOOL_TYPES))
+                raise Exception(
+                    "Tool type must be one of %s" % ",".join(VALID_TOOL_TYPES)
+                )
             else:
                 kwargs["tool_type"] = tool_type
 
@@ -62,7 +63,9 @@ class Tool(GalaxyXML):
                     if URL_method in VALID_URL_METHODS:
                         kwargs["URL_method"] = URL_method
                     else:
-                        raise Exception("URL_method must be one of %s" % ",".join(VALID_URL_METHODS))
+                        raise Exception(
+                            "URL_method must be one of %s" % ",".join(VALID_URL_METHODS)
+                        )
 
         description_node = etree.SubElement(self.root, "description")
         description_node.text = description
@@ -92,59 +95,27 @@ class Tool(GalaxyXML):
 
         return "\n".join(clean)
 
-    def export(self, keep_old_command=False):  # noqa
-        # from lib/galaxy/tool_util/linters/xml_order.py
-        # """This module contains a linting functions for tool XML block order.
-
-        # For more information on the IUC standard for XML block order see -
-        # https://github.com/galaxy-iuc/standards.
-        # """
-        # # https://github.com/galaxy-iuc/standards
-        # # https://github.com/galaxy-iuc/standards/pull/7/files
-        # TAG_ORDER = [
-            # 'description',
-            # 'macros',
-            # 'parallelism',
-            # 'requirements',
-            # 'code',
-            # 'stdio',
-            # 'version_command',
-            # 'command',
-            # 'environment_variables',
-            # 'configfiles',
-            # 'inputs',
-            # 'outputs',
-            # 'tests',
-            # 'help',
-            # 'citations',
-        # ]
-
-
+    def export(self, keep_old_command=False):
+        """see lib/galaxy/tool_util/linters/xml_order.py"""
         export_xml = copy.deepcopy(self)
-
         try:
             export_xml.append(export_xml.edam_operations)
         except Exception:
             pass
-
         try:
             export_xml.append(export_xml.edam_topics)
         except Exception:
             pass
-
         try:
             export_xml.append(export_xml.requirements)
         except Exception:
             pass
-
         # Add stdio section
         stdio = etree.SubElement(export_xml.root, "stdio")
         etree.SubElement(stdio, "exit_code", range="1:", level="fatal")
         export_xml.append(stdio)
-
         # Append version command
         export_xml.append_version_command()
-
         if self.command_override:
             command_line = self.command_override
         else:
@@ -158,12 +129,10 @@ class Tool(GalaxyXML):
                 command_line.append(export_xml.outputs.cli())
             except Exception:
                 pass
-
         # Steal interpreter from kwargs
         command_kwargs = {}
         if export_xml.interpreter is not None:
             command_kwargs["interpreter"] = export_xml.interpreter
-
         # Add command section
         command_node = etree.SubElement(export_xml.root, "command", **command_kwargs)
 
@@ -171,37 +140,37 @@ class Tool(GalaxyXML):
             if getattr(self, "command", None):
                 command_node.text = etree.CDATA(export_xml.command)
             else:
-                logger.warning("The tool does not have any old command stored. " + "Only the command line is written.")
+                logger.warning(
+                    "The tool does not have any old command stored. "
+                    + "Only the command line is written."
+                )
                 command_node.text = export_xml.executable
         else:
             if self.command_override:
                 actual_cli = export_xml.clean_command_string(command_line)
             else:
-                actual_cli = "%s %s" % (export_xml.executable, export_xml.clean_command_string(command_line))
+                actual_cli = "%s %s" % (
+                    export_xml.executable,
+                    export_xml.clean_command_string(command_line),
+                )
             command_node.text = etree.CDATA(actual_cli.strip())
-
         export_xml.append(command_node)
-
         try:
             export_xml.append(export_xml.configfiles)
         except Exception:
             pass
-
         try:
             export_xml.append(export_xml.inputs)
         except Exception:
             pass
-
         try:
             export_xml.append(export_xml.outputs)
         except Exception:
             pass
-
         try:
             export_xml.append(export_xml.tests)
         except Exception:
             pass
-
         help_element = etree.SubElement(export_xml.root, "help")
         help_element.text = etree.CDATA(export_xml.help)
         export_xml.append(help_element)
@@ -209,5 +178,4 @@ class Tool(GalaxyXML):
             export_xml.append(export_xml.citations)
         except Exception:
             pass
-
         return super(Tool, export_xml).export()

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -139,7 +139,7 @@ class Tool(GalaxyXML):
             else:
                 logger.warning(
                     "The tool does not have any old command stored. " + \
-                      "Only the command line is written."
+                    "Only the command line is written."
                 )
                 command_node.text = export_xml.executable
         else:

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -25,13 +25,11 @@ class XMLParam(object):
                 self.children.append(sub_node)
             else:
                 raise Exception(
-                    "Child was unacceptable to parent (%s is not appropriate for %s)"
-                    % (type(self), type(sub_node))
+                    "Child was unacceptable to parent (%s is not appropriate for %s)" % (type(self), type(sub_node))
                 )
         else:
             raise Exception(
-                "Child was unacceptable to parent (%s is not appropriate for %s)"
-                % (type(self), type(sub_node))
+                "Child was unacceptable to parent (%s is not appropriate for %s)" % (type(self), type(sub_node))
             )
 
     def validate(self):
@@ -52,6 +50,26 @@ class XMLParam(object):
 
     def command_line(self):
         return None
+
+
+class Stdios(XMLParam):
+    name = "stdio"
+
+    def acceptable_child(self, child):
+        return isinstance(child, Stdio)
+
+
+class Stdio(XMLParam):
+    name = "exit_code"
+
+    def __init__(
+        self,
+        range="1:",
+        level="fatal",
+        **kwargs,
+    ):
+        params = Util.clean_kwargs(locals().copy())
+        super(Stdio, self).__init__(**params)
 
 
 class RequestParamTranslation(XMLParam):
@@ -157,9 +175,7 @@ class Requirements(XMLParam):
     # This bodes to be an issue -__-
 
     def acceptable_child(self, child):
-        return issubclass(type(child), Requirement) or issubclass(
-            type(child), Container
-        )
+        return issubclass(type(child), Requirement) or issubclass(type(child), Container)
 
 
 class Requirement(XMLParam):
@@ -189,9 +205,7 @@ class Configfiles(XMLParam):
     name = "configfiles"
 
     def acceptable_child(self, child):
-        return issubclass(type(child), Configfile) or issubclass(
-            type(child), ConfigfileDefaultInputs
-        )
+        return issubclass(type(child), Configfile) or issubclass(type(child), ConfigfileDefaultInputs)
 
 
 class Configfile(XMLParam):
@@ -219,15 +233,7 @@ class Inputs(XMLParam):
     name = "inputs"
     # This bodes to be an issue -__-
 
-    def __init__(
-        self,
-        action=None,
-        check_value=None,
-        method=None,
-        target=None,
-        nginx_upload=None,
-        **kwargs,
-    ):
+    def __init__(self, action=None, check_value=None, method=None, target=None, nginx_upload=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())
         super(Inputs, self).__init__(**params)
 
@@ -264,9 +270,7 @@ class InputParameter(XMLParam):
             # TODO: replace with positional attribute
             if len(self.flag()) > 0:
                 if kwargs["label"] is None:
-                    kwargs[
-                        "label"
-                    ] = "Author did not provide help for this parameter... "
+                    kwargs["label"] = "Author did not provide help for this parameter... "
                 if not self.positional:
                     kwargs["argument"] = self.flag()
 
@@ -299,11 +303,7 @@ class InputParameter(XMLParam):
             if self.positional:
                 return self.mako_name()
             else:
-                return "%s%s%s" % (
-                    self.flag(),
-                    self.space_between_arg,
-                    self.mako_name(),
-                )
+                return "%s%s%s" % (self.flag(), self.space_between_arg, self.mako_name())
 
     def mako_name(self):
         # TODO: enhance logic to check up parents for things like
@@ -355,9 +355,7 @@ class Conditional(InputParameter):
         super(Conditional, self).__init__(**params)
 
     def acceptable_child(self, child):
-        return issubclass(type(child), InputParameter) and not isinstance(
-            child, Conditional
-        )
+        return issubclass(type(child), InputParameter) and not isinstance(child, Conditional)
 
     def validate(self):
         # Find a way to check if one of the kids is a WHEN
@@ -385,22 +383,16 @@ class Param(InputParameter):
         super(Param, self).__init__(**params)
 
         if type(self) == Param:
-            raise Exception(
-                "Param class is not an actual parameter type, use a subclass of Param"
-            )
+            raise Exception("Param class is not an actual parameter type, use a subclass of Param")
 
     def acceptable_child(self, child):
-        return issubclass(
-            type(child, InputParameter) or isinstance(child), ValidatorParam
-        )
+        return issubclass(type(child, InputParameter) or isinstance(child), ValidatorParam)
 
 
 class TextParam(Param):
     type = "text"
 
-    def __init__(
-        self, name, optional=None, label=None, help=None, value=None, **kwargs
-    ):
+    def __init__(self, name, optional=None, label=None, help=None, value=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())
         super(TextParam, self).__init__(**params)
 
@@ -415,17 +407,7 @@ class TextParam(Param):
 
 
 class _NumericParam(Param):
-    def __init__(
-        self,
-        name,
-        value,
-        optional=None,
-        label=None,
-        help=None,
-        min=None,
-        max=None,
-        **kwargs,
-    ):
+    def __init__(self, name, value, optional=None, label=None, help=None, min=None, max=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())
         super(_NumericParam, self).__init__(**params)
 
@@ -442,15 +424,7 @@ class BooleanParam(Param):
     type = "boolean"
 
     def __init__(
-        self,
-        name,
-        optional=None,
-        label=None,
-        help=None,
-        checked=False,
-        truevalue=None,
-        falsevalue=None,
-        **kwargs,
+        self, name, optional=None, label=None, help=None, checked=False, truevalue=None, falsevalue=None, **kwargs
     ):
         params = Util.clean_kwargs(locals().copy())
 
@@ -479,16 +453,7 @@ class BooleanParam(Param):
 class DataParam(Param):
     type = "data"
 
-    def __init__(
-        self,
-        name,
-        optional=None,
-        label=None,
-        help=None,
-        format=None,
-        multiple=None,
-        **kwargs,
-    ):
+    def __init__(self, name, optional=None, label=None, help=None, format=None, multiple=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())
         super(DataParam, self).__init__(**params)
 
@@ -507,7 +472,7 @@ class SelectParam(Param):
         multiple=None,
         options=None,
         default=None,
-        **kwargs,
+        **kwargs
     ):
         params = Util.clean_kwargs(locals().copy())
         del params["options"]
@@ -546,14 +511,7 @@ class SelectOption(InputParameter):
 class Options(InputParameter):
     name = "options"
 
-    def __init__(
-        self,
-        from_dataset=None,
-        from_file=None,
-        from_data_table=None,
-        from_parameter=None,
-        **kwargs,
-    ):
+    def __init__(self, from_dataset=None, from_file=None, from_data_table=None, from_parameter=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())
         super(Options, self).__init__(None, **params)
 
@@ -585,30 +543,10 @@ class Filter(InputParameter):
         value=None,
         ref_attribute=None,
         index=None,
-        **kwargs,
+        **kwargs
     ):
         params = Util.clean_kwargs(locals().copy())
         super(Filter, self).__init__(**params)
-
-
-class Stdios(XMLParam):
-    name = "stdio"
-
-    def acceptable_child(self, child):
-        return isinstance(child, Stdio)
-
-
-class Stdio(XMLParam):
-    name = "exit_code"
-
-    def __init__(
-        self,
-        range="1:",
-        level="fatal",
-        **kwargs,
-    ):
-        params = Util.clean_kwargs(locals().copy())
-        super(Stdio, self).__init__(**params)
 
 
 class ValidatorParam(InputParameter):
@@ -624,7 +562,7 @@ class ValidatorParam(InputParameter):
         line_startswith=None,
         min=None,
         max=None,
-        **kwargs,
+        **kwargs
     ):
         params = Util.clean_kwargs(locals().copy())
         super(ValidatorParam, self).__init__(**params)
@@ -638,7 +576,8 @@ class Outputs(XMLParam):
 
 
 class OutputData(XMLParam):
-    """Copypasta of InputParameter, needs work"""
+    """Copypasta of InputParameter, needs work
+    """
 
     name = "data"
 
@@ -651,7 +590,7 @@ class OutputData(XMLParam):
         label=None,
         from_work_dir=None,
         hidden=False,
-        **kwargs,
+        **kwargs
     ):
         # TODO: validate format_source&metadata_source against something in the
         # XMLParam children tree.
@@ -680,11 +619,7 @@ class OutputData(XMLParam):
         return flag + self.mako_identifier
 
     def acceptable_child(self, child):
-        return (
-            isinstance(child, OutputFilter)
-            or isinstance(child, ChangeFormat)
-            or isinstance(child, DiscoverDatasets)
-        )
+        return isinstance(child, OutputFilter) or isinstance(child, ChangeFormat) or isinstance(child, DiscoverDatasets)
 
 
 class OutputFilter(XMLParam):
@@ -734,25 +669,19 @@ class OutputCollection(XMLParam):
         type_source=None,
         structured_like=None,
         inherit_format=None,
-        **kwargs,
+        **kwargs
     ):
         params = Util.clean_kwargs(locals().copy())
         super(OutputCollection, self).__init__(**params)
 
     def acceptable_child(self, child):
-        return (
-            isinstance(child, OutputData)
-            or isinstance(child, OutputFilter)
-            or isinstance(child, DiscoverDatasets)
-        )
+        return isinstance(child, OutputData) or isinstance(child, OutputFilter) or isinstance(child, DiscoverDatasets)
 
 
 class DiscoverDatasets(XMLParam):
     name = "discover_datasets"
 
-    def __init__(
-        self, pattern, directory=None, format=None, ext=None, visible=None, **kwargs
-    ):
+    def __init__(self, pattern, directory=None, format=None, ext=None, visible=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())
         super(DiscoverDatasets, self).__init__(**params)
 
@@ -786,6 +715,7 @@ class TestOutput(XMLParam):
         self,
         name=None,
         file=None,
+        ftype=None,
         sort=None,
         value=None,
         md5=None,
@@ -793,7 +723,7 @@ class TestOutput(XMLParam):
         compare=None,
         lines_diff=None,
         delta=None,
-        **kwargs,
+        **kwargs
     ):
         params = Util.clean_kwargs(locals().copy())
         super(TestOutput, self).__init__(**params)

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -696,7 +696,6 @@ class TestOutput(XMLParam):
         self,
         name=None,
         file=None,
-        ftype=None,
         sort=None,
         value=None,
         md5=None,

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -661,8 +661,8 @@ class OutputData(XMLParam):
 
     def acceptable_child(self, child):
         return (
-            isinstance(child, OutputFilter) \
-            or isinstance(child, ChangeFormat) \
+            isinstance(child, OutputFilter)
+            or isinstance(child, ChangeFormat)
             or isinstance(child, DiscoverDatasets)
         )
 
@@ -721,8 +721,8 @@ class OutputCollection(XMLParam):
 
     def acceptable_child(self, child):
         return (
-            isinstance(child, OutputData) \
-            or isinstance(child, OutputFilter) \
+            isinstance(child, OutputData)
+            or isinstance(child, OutputFilter)
             or isinstance(child, DiscoverDatasets)
         )
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -6,7 +6,6 @@ from galaxyxml import Util
 from lxml import etree
 
 
-
 class XMLParam(object):
     name = "node"
 
@@ -26,11 +25,13 @@ class XMLParam(object):
                 self.children.append(sub_node)
             else:
                 raise Exception(
-                    "Child was unacceptable to parent (%s is not appropriate for %s)" % (type(self), type(sub_node))
+                    "Child was unacceptable to parent (%s is not appropriate for %s)"
+                    % (type(self), type(sub_node))
                 )
         else:
             raise Exception(
-                "Child was unacceptable to parent (%s is not appropriate for %s)" % (type(self), type(sub_node))
+                "Child was unacceptable to parent (%s is not appropriate for %s)"
+                % (type(self), type(sub_node))
             )
 
     def validate(self):
@@ -156,7 +157,9 @@ class Requirements(XMLParam):
     # This bodes to be an issue -__-
 
     def acceptable_child(self, child):
-        return issubclass(type(child), Requirement) or issubclass(type(child), Container)
+        return issubclass(type(child), Requirement) or issubclass(
+            type(child), Container
+        )
 
 
 class Requirement(XMLParam):
@@ -186,7 +189,9 @@ class Configfiles(XMLParam):
     name = "configfiles"
 
     def acceptable_child(self, child):
-        return issubclass(type(child), Configfile) or issubclass(type(child), ConfigfileDefaultInputs)
+        return issubclass(type(child), Configfile) or issubclass(
+            type(child), ConfigfileDefaultInputs
+        )
 
 
 class Configfile(XMLParam):
@@ -214,7 +219,15 @@ class Inputs(XMLParam):
     name = "inputs"
     # This bodes to be an issue -__-
 
-    def __init__(self, action=None, check_value=None, method=None, target=None, nginx_upload=None, **kwargs):
+    def __init__(
+        self,
+        action=None,
+        check_value=None,
+        method=None,
+        target=None,
+        nginx_upload=None,
+        **kwargs,
+    ):
         params = Util.clean_kwargs(locals().copy())
         super(Inputs, self).__init__(**params)
 
@@ -251,7 +264,9 @@ class InputParameter(XMLParam):
             # TODO: replace with positional attribute
             if len(self.flag()) > 0:
                 if kwargs["label"] is None:
-                    kwargs["label"] = "Author did not provide help for this parameter... "
+                    kwargs[
+                        "label"
+                    ] = "Author did not provide help for this parameter... "
                 if not self.positional:
                     kwargs["argument"] = self.flag()
 
@@ -284,7 +299,11 @@ class InputParameter(XMLParam):
             if self.positional:
                 return self.mako_name()
             else:
-                return "%s%s%s" % (self.flag(), self.space_between_arg, self.mako_name())
+                return "%s%s%s" % (
+                    self.flag(),
+                    self.space_between_arg,
+                    self.mako_name(),
+                )
 
     def mako_name(self):
         # TODO: enhance logic to check up parents for things like
@@ -336,7 +355,9 @@ class Conditional(InputParameter):
         super(Conditional, self).__init__(**params)
 
     def acceptable_child(self, child):
-        return issubclass(type(child), InputParameter) and not isinstance(child, Conditional)
+        return issubclass(type(child), InputParameter) and not isinstance(
+            child, Conditional
+        )
 
     def validate(self):
         # Find a way to check if one of the kids is a WHEN
@@ -364,16 +385,22 @@ class Param(InputParameter):
         super(Param, self).__init__(**params)
 
         if type(self) == Param:
-            raise Exception("Param class is not an actual parameter type, use a subclass of Param")
+            raise Exception(
+                "Param class is not an actual parameter type, use a subclass of Param"
+            )
 
     def acceptable_child(self, child):
-        return issubclass(type(child, InputParameter) or isinstance(child), ValidatorParam)
+        return issubclass(
+            type(child, InputParameter) or isinstance(child), ValidatorParam
+        )
 
 
 class TextParam(Param):
     type = "text"
 
-    def __init__(self, name, optional=None, label=None, help=None, value=None, **kwargs):
+    def __init__(
+        self, name, optional=None, label=None, help=None, value=None, **kwargs
+    ):
         params = Util.clean_kwargs(locals().copy())
         super(TextParam, self).__init__(**params)
 
@@ -388,7 +415,17 @@ class TextParam(Param):
 
 
 class _NumericParam(Param):
-    def __init__(self, name, value, optional=None, label=None, help=None, min=None, max=None, **kwargs):
+    def __init__(
+        self,
+        name,
+        value,
+        optional=None,
+        label=None,
+        help=None,
+        min=None,
+        max=None,
+        **kwargs,
+    ):
         params = Util.clean_kwargs(locals().copy())
         super(_NumericParam, self).__init__(**params)
 
@@ -405,7 +442,15 @@ class BooleanParam(Param):
     type = "boolean"
 
     def __init__(
-        self, name, optional=None, label=None, help=None, checked=False, truevalue=None, falsevalue=None, **kwargs
+        self,
+        name,
+        optional=None,
+        label=None,
+        help=None,
+        checked=False,
+        truevalue=None,
+        falsevalue=None,
+        **kwargs,
     ):
         params = Util.clean_kwargs(locals().copy())
 
@@ -434,7 +479,16 @@ class BooleanParam(Param):
 class DataParam(Param):
     type = "data"
 
-    def __init__(self, name, optional=None, label=None, help=None, format=None, multiple=None, **kwargs):
+    def __init__(
+        self,
+        name,
+        optional=None,
+        label=None,
+        help=None,
+        format=None,
+        multiple=None,
+        **kwargs,
+    ):
         params = Util.clean_kwargs(locals().copy())
         super(DataParam, self).__init__(**params)
 
@@ -453,7 +507,7 @@ class SelectParam(Param):
         multiple=None,
         options=None,
         default=None,
-        **kwargs
+        **kwargs,
     ):
         params = Util.clean_kwargs(locals().copy())
         del params["options"]
@@ -492,7 +546,14 @@ class SelectOption(InputParameter):
 class Options(InputParameter):
     name = "options"
 
-    def __init__(self, from_dataset=None, from_file=None, from_data_table=None, from_parameter=None, **kwargs):
+    def __init__(
+        self,
+        from_dataset=None,
+        from_file=None,
+        from_data_table=None,
+        from_parameter=None,
+        **kwargs,
+    ):
         params = Util.clean_kwargs(locals().copy())
         super(Options, self).__init__(None, **params)
 
@@ -524,7 +585,7 @@ class Filter(InputParameter):
         value=None,
         ref_attribute=None,
         index=None,
-        **kwargs
+        **kwargs,
     ):
         params = Util.clean_kwargs(locals().copy())
         super(Filter, self).__init__(**params)
@@ -543,7 +604,7 @@ class ValidatorParam(InputParameter):
         line_startswith=None,
         min=None,
         max=None,
-        **kwargs
+        **kwargs,
     ):
         params = Util.clean_kwargs(locals().copy())
         super(ValidatorParam, self).__init__(**params)
@@ -557,8 +618,7 @@ class Outputs(XMLParam):
 
 
 class OutputData(XMLParam):
-    """Copypasta of InputParameter, needs work
-    """
+    """Copypasta of InputParameter, needs work"""
 
     name = "data"
 
@@ -571,7 +631,7 @@ class OutputData(XMLParam):
         label=None,
         from_work_dir=None,
         hidden=False,
-        **kwargs
+        **kwargs,
     ):
         # TODO: validate format_source&metadata_source against something in the
         # XMLParam children tree.
@@ -600,7 +660,11 @@ class OutputData(XMLParam):
         return flag + self.mako_identifier
 
     def acceptable_child(self, child):
-        return isinstance(child, OutputFilter) or isinstance(child, ChangeFormat) or isinstance(child, DiscoverDatasets)
+        return (
+            isinstance(child, OutputFilter)
+            or isinstance(child, ChangeFormat)
+            or isinstance(child, DiscoverDatasets)
+        )
 
 
 class OutputFilter(XMLParam):
@@ -650,19 +714,25 @@ class OutputCollection(XMLParam):
         type_source=None,
         structured_like=None,
         inherit_format=None,
-        **kwargs
+        **kwargs,
     ):
         params = Util.clean_kwargs(locals().copy())
         super(OutputCollection, self).__init__(**params)
 
     def acceptable_child(self, child):
-        return isinstance(child, OutputData) or isinstance(child, OutputFilter) or isinstance(child, DiscoverDatasets)
+        return (
+            isinstance(child, OutputData)
+            or isinstance(child, OutputFilter)
+            or isinstance(child, DiscoverDatasets)
+        )
 
 
 class DiscoverDatasets(XMLParam):
     name = "discover_datasets"
 
-    def __init__(self, pattern, directory=None, format=None, ext=None, visible=None, **kwargs):
+    def __init__(
+        self, pattern, directory=None, format=None, ext=None, visible=None, **kwargs
+    ):
         params = Util.clean_kwargs(locals().copy())
         super(DiscoverDatasets, self).__init__(**params)
 
@@ -703,7 +773,7 @@ class TestOutput(XMLParam):
         compare=None,
         lines_diff=None,
         delta=None,
-        **kwargs
+        **kwargs,
     ):
         params = Util.clean_kwargs(locals().copy())
         super(TestOutput, self).__init__(**params)

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -591,6 +591,26 @@ class Filter(InputParameter):
         super(Filter, self).__init__(**params)
 
 
+class Stdios(XMLParam):
+    name = "stdio"
+
+    def acceptable_child(self, child):
+        return isinstance(child, Stdio)
+
+
+class Stdio(XMLParam):
+    name = "exit_code"
+
+    def __init__(
+        self,
+        range="1:",
+        level="fatal",
+        **kwargs,
+    ):
+        params = Util.clean_kwargs(locals().copy())
+        super(Stdio, self).__init__(**params)
+
+
 class ValidatorParam(InputParameter):
     name = "validator"
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -661,8 +661,8 @@ class OutputData(XMLParam):
 
     def acceptable_child(self, child):
         return (
-            isinstance(child, OutputFilter)
-            or isinstance(child, ChangeFormat)
+            isinstance(child, OutputFilter) \
+            or isinstance(child, ChangeFormat) \
             or isinstance(child, DiscoverDatasets)
         )
 
@@ -721,8 +721,8 @@ class OutputCollection(XMLParam):
 
     def acceptable_child(self, child):
         return (
-            isinstance(child, OutputData)
-            or isinstance(child, OutputFilter)
+            isinstance(child, OutputData) \
+            or isinstance(child, OutputFilter) \
             or isinstance(child, DiscoverDatasets)
         )
 


### PR DESCRIPTION
My attempt at fixing #27

Changed export order to match planemo's linter based on lib/galaxy/tool_util/linters/xml_order.py
Remove ftype from test output - planemo's linter declares it illegal

Needs more testing!
Generated ToolFactory code now passes tests and planemo lint for a couple of tools I regenerated...
