### PR TITLE
Topic/arg parse atrib order

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -72,6 +72,11 @@ options.append(filter_a)
 param.append(options)
 inputs.append(param)
 
+param = gxtp.Repeat("repeat", "repeat title")
+data = gxtp.DataParam("data", argument="--data", optional=True, format="fasta", multiple=True, label="data label", help="data help")
+param.append(data)
+inputs.append(param)
+
 # Configfiles
 configfiles = gxtp.Configfiles()
 configfiles.append(gxtp.Configfile(name="testing", text="Hello <> World"))

--- a/examples/example.py
+++ b/examples/example.py
@@ -29,8 +29,10 @@ inputs.append(param)
 
 # A float in a section
 section = gxtp.Section("float_section", "Float section")
-param = gxtp.FloatParam("float", label="Float label", help="Float help", value=0, num_dashes=1)
+param = gxtp.FloatParam("float", value=0, label="Float label", help="Float help", num_dashes=1)
 param.space_between_arg = " "
+section.append(param)
+param = gxtp.FloatParam(None, argument="--float-fromarg", value=0, label="Float label", help="Float help")
 section.append(param)
 inputs.append(section)
 

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -21,28 +21,29 @@ select_local $select_local]]></command>
     <inputs name="inputs"/>
   </configfiles>
   <inputs>
-    <param label="Flag label" help="Flag help" checked="false" type="boolean" name="flag" argument="-flag" truevalue="-flag" falsevalue=""/>
-    <section title="Float section" name="float_section">
-      <param label="Float label" help="Float help" value="0" type="float" name="float" argument="-float"/>
+    <param name="flag" type="boolean" label="Flag label" help="Flag help" checked="false" truevalue="-flag" falsevalue=""/>
+    <section name="float_section" title="Float section">
+      <param name="float" type="float" value="0" label="Float label" help="Float help"/>
+      <param argument="--float-fromarg" type="float" value="0" label="Float label" help="Float help"/>
     </section>
-    <conditional label="Conditional" name="cond" argument="cond">
-      <param label="Author did not provide help for this parameter... " type="select" name="Select" argument="Select">
+    <conditional name="cond" label="Conditional" argument="cond">
+      <param name="Select" type="select" label="Author did not provide help for this parameter... ">
         <option value="bye">2</option>
         <option value="hi">1</option>
       </param>
       <when value="hi"/>
       <when value="bye">
-        <param label="Advanced value" value="0" type="integer" name="some_int" argument="-some_int"/>
+        <param name="some_int" type="integer" value="0" label="Advanced value"/>
       </when>
     </conditional>
-    <param label="int_min label" help="int_min help" value="0" type="integer" name="int_min" argument="-int_min"/>
-    <param label="int_max label" help="int_max help" value="0" type="integer" name="int_max" argument="-int_max"/>
-    <param label="posint label" help="posinthelp" value="0" type="integer" name="posint"/>
-    <param label="Author did not provide help for this parameter... " type="select" name="select_local" argument="select_local">
+    <param name="int_min" type="integer" value="0" label="int_min label" help="int_min help"/>
+    <param name="int_max" type="integer" value="0" label="int_max label" help="int_max help"/>
+    <param name="posint" type="integer" value="0" label="posint label" help="posinthelp"/>
+    <param name="select_local" type="select" label="Author did not provide help for this parameter... ">
       <options from_file="loc_file.loc">
-        <column index="0" name="name"/>
-        <column index="1" name="value"/>
-        <filter type="sort_by" column="1" name="sorted"/>
+        <column name="name" index="0"/>
+        <column name="value" index="1"/>
+        <filter name="sorted" type="sort_by" column="1"/>
       </options>
     </param>
   </inputs>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -10,12 +10,18 @@
   </stdio>
   <version_command><![CDATA[aragorn.exe --version]]></version_command>
   <command><![CDATA[aragorn.exe $flag
-float_section $float_section
-cond $cond
+-float $float
+--float-fromarg $float_fromarg
+#if str($Select) == "bye"
+-some_int $some_int
+#end if
 -i$int_min,$int_max
 
 $posint
-select_local $select_local]]></command>
+select_local $select_local
+#for $i in $repeat:
+--data $data
+#end for]]></command>
   <configfiles>
     <configfile name="testing"><![CDATA[Hello <> World]]></configfile>
     <inputs name="inputs"/>
@@ -26,7 +32,7 @@ select_local $select_local]]></command>
       <param name="float" type="float" value="0" label="Float label" help="Float help"/>
       <param argument="--float-fromarg" type="float" value="0" label="Float label" help="Float help"/>
     </section>
-    <conditional name="cond" label="Conditional" argument="cond">
+    <conditional name="cond" label="Conditional">
       <param name="Select" type="select" label="Author did not provide help for this parameter... ">
         <option value="bye">2</option>
         <option value="hi">1</option>
@@ -46,6 +52,9 @@ select_local $select_local]]></command>
         <filter name="sorted" type="sort_by" column="1"/>
       </options>
     </param>
+    <repeat name="repeat" title="repeat title">
+      <param name="data" argument="--data" type="data" optional="true" label="data label" help="data help" format="fasta" multiple="true"/>
+    </repeat>
   </inputs>
   <outputs>
     <data name="output" format="tabular" hidden="false"/>

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -19,6 +19,19 @@ class XMLParam(object):
         kwargs = Util.clean_kwargs(kwargs, final=True)
         self.node = etree.Element(self.name, **kwargs)
 
+    def __getattr__(self, name):
+        """
+        Allow to access keys of the node "attributes" (i.e. the dict
+        self.node.attrib) as attributes.
+        """
+        # https://stackoverflow.com/questions/47299243/recursionerror-when-python-copy-deepcopy
+        if name == "__setstate__":
+            raise AttributeError(name)
+        try:
+            return self.node.attrib[name]
+        except KeyError:
+            raise AttributeError(name)
+
     def append(self, sub_node):
         if self.acceptable_child(sub_node):
             # If one of ours, they aren't etree nodes, they're custom objects
@@ -63,9 +76,7 @@ class Stdios(XMLParam):
 class Stdio(XMLParam):
     name = "exit_code"
 
-    def __init__(
-        self, range="1:", level="fatal", **kwargs,
-    ):
+    def __init__(self, range="1:", level="fatal", **kwargs):
         params = Util.clean_kwargs(locals().copy())
         super(Stdio, self).__init__(**params)
 
@@ -393,7 +404,6 @@ class When(InputParameter):
     name = "when"
 
     def __init__(self, value):
-        self.value = value
         params = Util.clean_kwargs(locals().copy())
         super(When, self).__init__(None, **params)
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -17,7 +17,6 @@ class XMLParam(object):
         kwargs = {k: v for k, v in list(kwargs.items()) if v is not None}
         kwargs = Util.coerce(kwargs, kill_lists=True)
         kwargs = Util.clean_kwargs(kwargs, final=True)
-        
         self.node = etree.Element(self.name, **kwargs)
 
     def append(self, sub_node):
@@ -245,7 +244,7 @@ class InputParameter(XMLParam):
         # TODO: look at
         if "argument" in kwargs and kwargs['argument']:
             self.flag_identifier = kwargs['argument'].lstrip()
-            self.num_dashes = len(kwargs['argument'])-len(self.flag_identifier) 
+            self.num_dashes = len(kwargs['argument']) - len(self.flag_identifier)
             self.mako_identifier = _parse_name(name, kwargs['argument'])
         else:
             self.flag_identifier = name
@@ -374,7 +373,7 @@ class Conditional(InputParameter):
         else:
             return False
 #         return issubclass(type(child), InputParameter) and not isinstance(child, Conditional)
-    
+
     def command_line(self):
         lines = []
         for c in self.children[1:]:
@@ -408,9 +407,9 @@ class Param(InputParameter):
     # This...isn't really valid as-is, and shouldn't be used.
     def __init__(self, name, argument=None, value=None, optional=None, label=None, help=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())
-        params = dict([("name", params["name"]), 
-            ("argument", params["argument"]),
-            ("type", self.type)] + list(params.items()))
+        params = dict([("name", params["name"]),
+                      ("argument", params["argument"]),
+                      ("type", self.type)] + list(params.items()))
         super(Param, self).__init__(**params)
 
         if type(self) == Param:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="Galaxy XML generation library",
     author="Helena Rasche",
     author_email="hxr@hx42.org",
-    install_requires=["lxml"],
+    install_requires=["lxml", "galaxy-tool-util"],
     long_description=readme,
     long_description_content_type="text/x-rst",
     packages=["galaxyxml", "galaxyxml.tool", "galaxyxml.tool.parameters"],


### PR DESCRIPTION
if argument is given then properly extract flag and identifier:

- flag equal to argument
- identifier: argument wo leading dashes and - replaced by _

some reordering of attributes for params:

- it is nicer if its name, argument, type, ...
- mostly dictated by the order of the function parameters using that dicts are ordered by insertion order nowadays
- only type and name (which are computed)  need a hacky special treatment

actually generate CLI for conditionals, sections and repeats.

- A small improvement, even if the cheetah is not yet correct.

