### PR TITLE
Add TestOutputCollection so collections can be tested and TestRepeat for repeats.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Changelog
 ---------
 -  0.4.13
 
-   - Add TestOutputCollection and tests (thanks @fubar2)
+   - Add TestOutputCollection, TestRepeat and tests (thanks @fubar2)
 
 -  0.4.12
 

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,9 @@ License
 
 Changelog
 ---------
+-  0.4.13
+
+   - Add TestOutputCollection and tests (thanks @fubar2)
 
 -  0.4.12
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -104,7 +104,7 @@ param = gxtp.TestParam("float", value=5.4)
 test_a.append(param)
 test_out = gxtp.TestOutput(name="output", value="file.out")
 test_a.append(test_out)
-coll_out = gxtp.TestOutputCollection(name="coll_out")
+coll_out = gxtp.TestOutputCollection(name="pdf_out")
 test_a.append(coll_out)
 tool.tests.append(test_a)
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -106,6 +106,10 @@ test_out = gxtp.TestOutput(name="output", value="file.out")
 test_a.append(test_out)
 coll_out = gxtp.TestOutputCollection(name="pdf_out")
 test_a.append(coll_out)
+rep_out = gxtp.TestRepeat(name="testrepeat")
+param = gxtp.TestParam("repeatchild", value="foo")
+rep_out.append(param)
+test_a.append(rep_out)
 tool.tests.append(test_a)
 
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -104,6 +104,8 @@ param = gxtp.TestParam("float", value=5.4)
 test_a.append(param)
 test_out = gxtp.TestOutput(name="output", value="file.out")
 test_a.append(test_out)
+coll_out = gxtp.TestOutputCollection(name="coll_out")
+test_a.append(coll_out)
 tool.tests.append(test_a)
 
 

--- a/examples/example_macros.xml
+++ b/examples/example_macros.xml
@@ -9,7 +9,8 @@
 
 $posint
 select_local $select_local]]></token>
-  <token name="ARAGORN_OUTMACRO"><![CDATA[]]></token>
+  <token name="ARAGORN_OUTMACRO"><![CDATA[-output '$output'
+## TODO CLI for OutputCollection collection]]></token>
   <xml name="aragorn_inmacro">
     <param name="flag" type="boolean" label="Flag label" help="Flag help" checked="false" truevalue="-flag" falsevalue=""/>
     <section name="float_section" title="Float section">

--- a/examples/example_macros.xml
+++ b/examples/example_macros.xml
@@ -9,8 +9,7 @@
 
 $posint
 select_local $select_local]]></token>
-  <token name="ARAGORN_OUTMACRO"><![CDATA[-output '$output'
-## TODO CLI for OutputCollection collection]]></token>
+  <token name="ARAGORN_OUTMACRO"><![CDATA[]]></token>
   <xml name="aragorn_inmacro">
     <param name="flag" type="boolean" label="Flag label" help="Flag help" checked="false" truevalue="-flag" falsevalue=""/>
     <section name="float_section" title="Float section">

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -67,6 +67,7 @@ select_local $select_local
     <test>
       <param name="float" value="5.4"/>
       <output name="output" value="file.out"/>
+      <output_collection name="coll_out"/>
     </test>
   </tests>
   <help><![CDATA[HI]]></help>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -68,6 +68,9 @@ select_local $select_local
       <param name="float" value="5.4"/>
       <output name="output" value="file.out"/>
       <output_collection name="pdf_out"/>
+      <test_repeat name="testrepeat">
+        <param name="repeatchild" value="foo"/>
+      </test_repeat>
     </test>
   </tests>
   <help><![CDATA[HI]]></help>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -67,7 +67,7 @@ select_local $select_local
     <test>
       <param name="float" value="5.4"/>
       <output name="output" value="file.out"/>
-      <output_collection name="coll_out"/>
+      <output_collection name="pdf_out"/>
     </test>
   </tests>
   <help><![CDATA[HI]]></help>

--- a/galaxyxml/__init__.py
+++ b/galaxyxml/__init__.py
@@ -1,6 +1,6 @@
 from builtins import (
-    str,
-    object
+    object,
+    str
 )
 
 from lxml import etree

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -709,12 +709,9 @@ class TestsParser(object):
         test_root.append(
             gxtp.TestOutputCollection(
                 name=output_root.attrib.get("name", None),
-                file=output_root.attrib.get("file", None),
                 ftype=output_root.attrib.get("ftype", None),
                 sort=output_root.attrib.get("sort", None),
                 value=output_root.attrib.get("value", None),
-                md5=output_root.attrib.get("md5", None),
-                checksum=output_root.attrib.get("checksum", None),
                 compare=output_root.attrib.get("compare", None),
                 lines_diff=output_root.attrib.get("lines_diff", None),
                 delta=output_root.attrib.get("delta", None),

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -728,13 +728,13 @@ class TestsParser(object):
         """
 
         repeat = gxtp.TestRepeat(
-                repeat_root.attrib.get("name", None),
-                repeat_root.attrib.get("title",None),
-                min=repeat_root.attrib.get("min", None),
-                max=repeat_root.attrib.get("max", None),
-                default=repeat_root.attrib.get("default", None)
-            )
-       # Deal with child nodes
+            repeat_root.attrib.get("name", None),
+            repeat_root.attrib.get("title",None),
+            min=repeat_root.attrib.get("min", None),
+            max=repeat_root.attrib.get("max", None),
+            default=repeat_root.attrib.get("default", None)
+        )
+        # Deal with child nodes
         self.load_inputs(repeat, repeat_root)
         root.append(repeat)
 
@@ -750,7 +750,7 @@ class TestsParser(object):
             try:
                 getattr(self, "_load_{}".format(rep_child.tag))(repeat, rep_child)
             except AttributeError:
-                logger.warning(inp_child.tag + " tag is not processed for <" + repeat_root.tag + "> tag.")
+                logger.warning(rep_child.tag + " tag is not processed for <" + repeat_root.tag + "> tag.")
 
     def load_tests(self, root, tests_root):
         """

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -698,6 +698,30 @@ class TestsParser(object):
             )
         )
 
+    def _load_output_collection(self, test_root, output_root):
+        """
+        Add <output_collection> to the <test>.
+
+        :param root: <test> root to append <output> to.
+        :param repeat_root: root of <output_collection> tag.
+        :param repeat_root: :class:`xml.etree._Element`
+        """
+        test_root.append(
+            gxtp.TestOutputCollection(
+                name=output_root.attrib.get("name", None),
+                file=output_root.attrib.get("file", None),
+                ftype=output_root.attrib.get("ftype", None),
+                sort=output_root.attrib.get("sort", None),
+                value=output_root.attrib.get("value", None),
+                md5=output_root.attrib.get("md5", None),
+                checksum=output_root.attrib.get("checksum", None),
+                compare=output_root.attrib.get("compare", None),
+                lines_diff=output_root.attrib.get("lines_diff", None),
+                delta=output_root.attrib.get("delta", None),
+            )
+        )
+
+
     def load_tests(self, root, tests_root):
         """
         Add <tests> to the root.

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -721,6 +721,23 @@ class TestsParser(object):
             )
         )
 
+    def _load_repeat(self, test_root, output_root):
+        """
+        Add <test_repeat> to the <test>.
+
+        :param root: <test> root to append <output> to.
+        :param output_root: root of <test_repeat> tag.
+        :param output_root: :class:`xml.etree._Element`
+        """
+        test_root.append(
+            gxtp.TestRepeat(
+                output_root.attrib.get("name", None),
+                output_root.attrib.get("title",None),
+                min=output_root.attrib.get("min", None),
+                max=output_root.attrib.get("max", None),
+                default=output_root.attrib.get("default", None)
+            )
+        )
 
     def load_tests(self, root, tests_root):
         """

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -721,7 +721,7 @@ class TestsParser(object):
             )
         )
 
-    def _load_repeat(self, test_root, output_root):
+    def _load_repeat(self, root, repeat_root):
         """
         Add <test_repeat> to the <test>.
 
@@ -729,15 +729,31 @@ class TestsParser(object):
         :param output_root: root of <test_repeat> tag.
         :param output_root: :class:`xml.etree._Element`
         """
-        test_root.append(
-            gxtp.TestRepeat(
-                output_root.attrib.get("name", None),
-                output_root.attrib.get("title",None),
-                min=output_root.attrib.get("min", None),
-                max=output_root.attrib.get("max", None),
-                default=output_root.attrib.get("default", None)
+
+        repeat = gxtp.TestRepeat(
+                repeat_root.attrib.get("name", None),
+                repeat_root.attrib.get("title",None),
+                min=repeat_root.attrib.get("min", None),
+                max=repeat_root.attrib.get("max", None),
+                default=repeat_root.attrib.get("default", None)
             )
-        )
+       # Deal with child nodes
+        self.load_inputs(repeat, repeat_root)
+        root.append(repeat)
+
+    def load_inputs(self, repeat, repeat_root):
+        """
+        Add children to repeat for test
+
+        :param repeat_root: repeat to attach inputs to.
+        :param repeat: root of <repeat> tag.
+        :type repeat_root: :class:`xml.etree._Element`
+        """
+        for rep_child in repeat_root:
+            try:
+                getattr(self, "_load_{}".format(rep_child.tag))(repeat, rep_child)
+            except AttributeError:
+                logger.warning(inp_child.tag + " tag is not processed for <" + repeat_root.tag + "> tag.")
 
     def load_tests(self, root, tests_root):
         """

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -1,12 +1,13 @@
-from builtins import (
-    str,
-    object
-)
 import logging
+from builtins import (
+    object,
+    str
+)
+
+from galaxy.tool_util.parser.util import _parse_name
 
 from galaxyxml import Util
 
-from galaxy.tool_util.parser.util import _parse_name
 from lxml import etree
 
 logging.basicConfig(level=logging.INFO)
@@ -860,6 +861,7 @@ class Test(XMLParam):
         return isinstance(child, TestParam) \
             or isinstance(child, TestOutput) \
             or isinstance(child, TestOutputCollection) \
+            or isinstance(child, TestRepeat) \
             or isinstance(child, Expand)
 
 
@@ -916,7 +918,40 @@ class TestOutputCollection(XMLParam):
         return "</output_collection>"
 
     def command_line_actual(self, mako_path):
+
         return ""
+
+class TestRepeat(XMLParam):
+    name = "repeat"
+
+    def __init__(
+        self,
+        name=None,
+        ftype=None,
+        sort=None,
+        value=None,
+        compare=None,
+        lines_diff=None,
+        delta=None,
+        **kwargs,
+    ):
+        params = Util.clean_kwargs(locals().copy())
+        super(TestRepeat, self).__init__(**params)
+
+    def acceptable_child(self, child):
+        return issubclass(type(child), TestParam)
+
+    def command_line_before(self, mako_path):
+        return "<repeat name = '%s'>" % self.name
+
+    def command_line_after(self):
+        return "</repeat>"
+
+    def command_line_actual(self, mako_path):
+        lines = []
+        for child in self.children:
+            lines.append(child.command_line())
+        return "\n".join(lines)
 
 
 class Citations(XMLParam):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -859,6 +859,7 @@ class Test(XMLParam):
     def acceptable_child(self, child):
         return isinstance(child, TestParam) \
             or isinstance(child, TestOutput) \
+            or isinstance(child, TestOutputCollection) \
             or isinstance(child, Expand)
 
 
@@ -889,6 +890,33 @@ class TestOutput(XMLParam):
     ):
         params = Util.clean_kwargs(locals().copy())
         super(TestOutput, self).__init__(**params)
+
+
+class TestOutputCollection(XMLParam):
+    name = "output_collection"
+
+    def __init__(
+        self,
+        name=None,
+        ftype=None,
+        sort=None,
+        value=None,
+        compare=None,
+        lines_diff=None,
+        delta=None,
+        **kwargs,
+    ):
+        params = Util.clean_kwargs(locals().copy())
+        super(TestOutputCollection, self).__init__(**params)
+
+    def command_line_before(self, mako_path):
+        return "<output_collection name = '%s'>" % self.name
+
+    def command_line_after(self):
+        return "</output_collection>"
+
+    def command_line_actual(self, mako_path):
+        return ""
 
 
 class Citations(XMLParam):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst") as fh:
 
 setup(
     name="galaxyxml",
-    version="0.4.13",
+    version="0.4.14",
     description="Galaxy XML generation library",
     author="Helena Rasche",
     author_email="hxr@hx42.org",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst") as fh:
 
 setup(
     name="galaxyxml",
-    version="0.4.12",
+    version="0.4.13",
     description="Galaxy XML generation library",
     author="Helena Rasche",
     author_email="hxr@hx42.org",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst") as fh:
 
 setup(
     name="galaxyxml",
-    version="0.4.14",
+    version="0.4.13",
     description="Galaxy XML generation library",
     author="Helena Rasche",
     author_email="hxr@hx42.org",

--- a/test/import_xml.xml
+++ b/test/import_xml.xml
@@ -71,6 +71,7 @@
     <test>
       <param name="sequence" value="seq.fasta"/>
       <output file="file.gbk" name="genbank"/>
+      <output_collection name="pdf_out"></output_collection>
     </test>
   </tests>
   <help><![CDATA[help]]></help>

--- a/test/import_xml.xml
+++ b/test/import_xml.xml
@@ -72,6 +72,9 @@
       <param name="sequence" value="seq.fasta"/>
       <output file="file.gbk" name="genbank"/>
       <output_collection name="pdf_out"></output_collection>
+      <repeat name="test_repeat">
+          <param name="repeatchild" value="foo"/>
+      </repeat>
     </test>
   </tests>
   <help><![CDATA[help]]></help>

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -198,7 +198,8 @@ class TestTestsParser(TestImport):
         self.assertEqual(output.attrib["name"], "pdf_out")
 
     def test_repeat(self):
-        output = self.tool.tests.children[0].node[3]
-        self.assertEqual(output.attrib["name"],"test_repeat")
-        # how to test the repeat's parameter is parsed?
-
+        repeat = self.tool.tests.children[0].node[3]
+        self.assertEqual(repeat.attrib["name"],"test_repeat")
+        # test param within repeat
+        self.assertEqual(repeat[0].attrib["name"], "repeatchild")
+        self.assertEqual(repeat[0].attrib["value"], "foo")

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -192,3 +192,8 @@ class TestTestsParser(TestImport):
         output = self.tool.tests.children[0].node[1]
         self.assertEqual(output.attrib["file"], "file.gbk")
         self.assertEqual(output.attrib["name"], "genbank")
+
+    def test_collection_output(self):
+        output = self.tool.tests.children[0].node[2]
+        self.assertEqual(output.attrib["name"], "pdf_out.foo")
+

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -195,5 +195,5 @@ class TestTestsParser(TestImport):
 
     def test_collection_output(self):
         output = self.tool.tests.children[0].node[2]
-        self.assertEqual(output.attrib["name"], "pdf_out.foo")
+        self.assertEqual(output.attrib["name"], "pdf_out")
 

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -197,3 +197,8 @@ class TestTestsParser(TestImport):
         output = self.tool.tests.children[0].node[2]
         self.assertEqual(output.attrib["name"], "pdf_out")
 
+    def test_repeat(self):
+        output = self.tool.tests.children[0].node[3]
+        self.assertEqual(output.attrib["name"],"test_repeat")
+        # how to test the repeat's parameter is parsed?
+


### PR DESCRIPTION
This PR adds TestOutputCollection and allows the ToolFactory to generate tools with dummy tests for output collections that pass planemo test. Version bumped...

Arguably, needs extension so individual file names expected to be in the collection can be checked - that will require knowledge that we cannot sanely introspect automagically so will need yet more information on the collection tool form section.

Very lightly tested (TM) - just the plotter tool example.

Suggestions appreciated....

TestRepeat added with tests. Also very lightly tested with a real tool.
