### PR TITLE
Fixes to collections and repeats - now possible to test collections with elements and repeats with collections....

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ License
 
 Changelog
 ---------
+-  0.4.14
+
+   - Fix for TestRepeats (@fubar2)
+
 -  0.4.13
 
    - Add TestOutputCollection, TestRepeat and tests (thanks @fubar2)

--- a/examples/example.py
+++ b/examples/example.py
@@ -97,23 +97,6 @@ tool.outputs = outputs
 tool.help = "HI"
 tool.configfiles = configfiles
 
-      # <param name="sequence" value="seq.fasta"/>
-      # <output file="file.gbk" name="genbank"/>
-      # <output_collection name="pdf_out">
-         # <element name="apdf" file="apdf" ftype="pdf"/>
-      # </output_collection>
-      # <test_repeat name="testrepeat">
-          # <param name="repeatchild" value="foo"/>
-      # </test_repeat>
-      # <test_repeat name="output_repeat">
-          # <output file="outputchild" name="bar"/>
-      # </test_repeat>
-      # <test_repeat name="collection_repeat">
-          # <output_collection name="collectionchild">
-              # <element name="elementary" file="efile" ftype="txt"/>
-          # </output_collection>
-      # </test_repeat>
-
 # Add Tests sections
 tool.tests = gxtp.Tests()
 test_a = gxtp.Test()

--- a/examples/example.py
+++ b/examples/example.py
@@ -97,6 +97,23 @@ tool.outputs = outputs
 tool.help = "HI"
 tool.configfiles = configfiles
 
+      # <param name="sequence" value="seq.fasta"/>
+      # <output file="file.gbk" name="genbank"/>
+      # <output_collection name="pdf_out">
+         # <element name="apdf" file="apdf" ftype="pdf"/>
+      # </output_collection>
+      # <test_repeat name="testrepeat">
+          # <param name="repeatchild" value="foo"/>
+      # </test_repeat>
+      # <test_repeat name="output_repeat">
+          # <output file="outputchild" name="bar"/>
+      # </test_repeat>
+      # <test_repeat name="collection_repeat">
+          # <output_collection name="collectionchild">
+              # <element name="elementary" file="efile" ftype="txt"/>
+          # </output_collection>
+      # </test_repeat>
+
 # Add Tests sections
 tool.tests = gxtp.Tests()
 test_a = gxtp.Test()
@@ -108,6 +125,14 @@ coll_out = gxtp.TestOutputCollection(name="pdf_out")
 test_a.append(coll_out)
 rep_out = gxtp.TestRepeat(name="testrepeat")
 param = gxtp.TestParam("repeatchild", value="foo")
+rep_out.append(param)
+test_a.append(rep_out)
+test_coll = gxtp.TestOutputCollection(name="pdf_out")
+test_elem = gxtp.TestOCElement(name="apdf",file="apdf",ftype="pdf")
+test_coll.append(test_elem)
+test_a.append(test_coll)
+rep_out = gxtp.TestRepeat(name="output_repeat")
+param = gxtp.TestOutput(name="repeatout", value="repeatfile.out")
 rep_out.append(param)
 test_a.append(rep_out)
 tool.tests.append(test_a)

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -71,6 +71,12 @@ select_local $select_local
       <test_repeat name="testrepeat">
         <param name="repeatchild" value="foo"/>
       </test_repeat>
+      <output_collection name="pdf_out">
+        <element name="apdf" file="apdf" ftype="pdf"/>
+      </output_collection>
+      <test_repeat name="output_repeat">
+        <output name="repeatout" value="repeatfile.out"/>
+      </test_repeat>
     </test>
   </tests>
   <help><![CDATA[HI]]></help>

--- a/examples/tool.xml
+++ b/examples/tool.xml
@@ -68,15 +68,15 @@ select_local $select_local
       <param name="float" value="5.4"/>
       <output name="output" value="file.out"/>
       <output_collection name="pdf_out"/>
-      <test_repeat name="testrepeat">
+      <repeat name="testrepeat">
         <param name="repeatchild" value="foo"/>
-      </test_repeat>
+      </repeat>
       <output_collection name="pdf_out">
         <element name="apdf" file="apdf" ftype="pdf"/>
       </output_collection>
-      <test_repeat name="output_repeat">
+      <repeat name="output_repeat">
         <output name="repeatout" value="repeatfile.out"/>
-      </test_repeat>
+      </repeat>
     </test>
   </tests>
   <help><![CDATA[HI]]></help>

--- a/galaxyxml/tool/__init__.py
+++ b/galaxyxml/tool/__init__.py
@@ -138,7 +138,7 @@ class Tool(GalaxyXML):
             stdio_element = etree.SubElement(export_xml.root, "stdio")
             etree.SubElement(stdio_element, "exit_code", range="1:", level="fatal")
         try:
-            export_xml.append(export_xml.stdio)
+            export_xml.append(stdio_element)
         except Exception:
             export_xml.append(Expand(macro="stdio"))
 

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -719,10 +719,10 @@ class TestsParser(object):
         self.load_inputs(collection, output_root)
         test_root.append(collection)
 
-
     def _load_element(self, test_root, element_root):
         """
         Add <element> to the <test>.
+
         :param root: <test> root to append <output> to.
         :param repeat_root: root of <output_collection> tag.
         :param repeat_root: :class:`xml.etree._Element`
@@ -734,7 +734,6 @@ class TestsParser(object):
         )
         )
 
-
     def _load_repeat(self, test_root, repeat_root):
         """
         Add <repeat> to the <test>.
@@ -743,10 +742,9 @@ class TestsParser(object):
         :param output_root: root of <repeat> tag.
         :param output_root: :class:`xml.etree._Element`
         """
-
         repeat = gxtp.TestRepeat(
             repeat_root.attrib.get("name", None),
-            repeat_root.attrib.get("title",None),
+            repeat_root.attrib.get("title", None),
             min=repeat_root.attrib.get("min", None),
             max=repeat_root.attrib.get("max", None),
             default=repeat_root.attrib.get("default", None)
@@ -754,7 +752,6 @@ class TestsParser(object):
         # Deal with child nodes
         self.load_inputs(repeat, repeat_root)
         test_root.append(repeat)
-
 
     def load_inputs(self, repeat, repeat_root):
         """

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -706,8 +706,7 @@ class TestsParser(object):
         :param repeat_root: root of <output_collection> tag.
         :param repeat_root: :class:`xml.etree._Element`
         """
-        test_root.append(
-            gxtp.TestOutputCollection(
+        collection = gxtp.TestOutputCollection(
                 name=output_root.attrib.get("name", None),
                 ftype=output_root.attrib.get("ftype", None),
                 sort=output_root.attrib.get("sort", None),
@@ -716,9 +715,27 @@ class TestsParser(object):
                 lines_diff=output_root.attrib.get("lines_diff", None),
                 delta=output_root.attrib.get("delta", None),
             )
+        # Deal with child nodes
+        self.load_inputs(collection, output_root)
+        test_root.append(collection)
+
+
+    def _load_element(self, test_root, element_root):
+        """
+        Add <element> to the <test>.
+        :param root: <test> root to append <output> to.
+        :param repeat_root: root of <output_collection> tag.
+        :param repeat_root: :class:`xml.etree._Element`
+        """
+        test_root.append(gxtp.TestOCElement(
+                name=element_root.attrib.get("name", None),
+                ftype=element_root.attrib.get("ftype", None),
+                file=element_root.attrib.get("file", None)
+                )
         )
 
-    def _load_repeat(self, root, repeat_root):
+
+    def _load_test_repeat(self, test_root, repeat_root):
         """
         Add <test_repeat> to the <test>.
 
@@ -736,14 +753,15 @@ class TestsParser(object):
         )
         # Deal with child nodes
         self.load_inputs(repeat, repeat_root)
-        root.append(repeat)
+        test_root.append(repeat)
+
 
     def load_inputs(self, repeat, repeat_root):
         """
-        Add children to repeat for test
+        Add children to repeat/collection for test
 
         :param repeat_root: repeat to attach inputs to.
-        :param repeat: root of <repeat> tag.
+        :param repeat: root of <repeat> or <collection> tag.
         :type repeat_root: :class:`xml.etree._Element`
         """
         for rep_child in repeat_root:

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -735,12 +735,12 @@ class TestsParser(object):
         )
 
 
-    def _load_test_repeat(self, test_root, repeat_root):
+    def _load_repeat(self, test_root, repeat_root):
         """
-        Add <test_repeat> to the <test>.
+        Add <repeat> to the <test>.
 
         :param root: <test> root to append <output> to.
-        :param output_root: root of <test_repeat> tag.
+        :param output_root: root of <repeat> tag.
         :param output_root: :class:`xml.etree._Element`
         """
 

--- a/galaxyxml/tool/import_xml.py
+++ b/galaxyxml/tool/import_xml.py
@@ -707,14 +707,14 @@ class TestsParser(object):
         :param repeat_root: :class:`xml.etree._Element`
         """
         collection = gxtp.TestOutputCollection(
-                name=output_root.attrib.get("name", None),
-                ftype=output_root.attrib.get("ftype", None),
-                sort=output_root.attrib.get("sort", None),
-                value=output_root.attrib.get("value", None),
-                compare=output_root.attrib.get("compare", None),
-                lines_diff=output_root.attrib.get("lines_diff", None),
-                delta=output_root.attrib.get("delta", None),
-            )
+            name=output_root.attrib.get("name", None),
+            ftype=output_root.attrib.get("ftype", None),
+            sort=output_root.attrib.get("sort", None),
+            value=output_root.attrib.get("value", None),
+            compare=output_root.attrib.get("compare", None),
+            lines_diff=output_root.attrib.get("lines_diff", None),
+            delta=output_root.attrib.get("delta", None),
+        )
         # Deal with child nodes
         self.load_inputs(collection, output_root)
         test_root.append(collection)
@@ -728,10 +728,10 @@ class TestsParser(object):
         :param repeat_root: :class:`xml.etree._Element`
         """
         test_root.append(gxtp.TestOCElement(
-                name=element_root.attrib.get("name", None),
-                ftype=element_root.attrib.get("ftype", None),
-                file=element_root.attrib.get("file", None)
-                )
+            name=element_root.attrib.get("name", None),
+            ftype=element_root.attrib.get("ftype", None),
+            file=element_root.attrib.get("file", None)
+        )
         )
 
 

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -939,7 +939,9 @@ class TestRepeat(XMLParam):
         super(TestRepeat, self).__init__(**params)
 
     def acceptable_child(self, child):
-        return issubclass(type(child), TestParam)
+        return issubclass(type(child), TestParam) \
+        or  issubclass(type(child), TestOutput) \
+         or issubclass(type(child), TestOutputCollection)
 
     def command_line_before(self, mako_path):
         return "<repeat name = '%s'>" % self.name

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -940,8 +940,8 @@ class TestRepeat(XMLParam):
 
     def acceptable_child(self, child):
         return issubclass(type(child), TestParam) \
-        or  issubclass(type(child), TestOutput) \
-         or issubclass(type(child), TestOutputCollection)
+            or  issubclass(type(child), TestOutput) \
+            or issubclass(type(child), TestOutputCollection)
 
     def command_line_before(self, mako_path):
         return "<repeat name = '%s'>" % self.name

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -13,6 +13,7 @@ from lxml import etree
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class XMLParam(object):
     name = "node"
 
@@ -69,7 +70,7 @@ class XMLParam(object):
             lines.append(child.command_line())
         return "\n".join(lines)
 
-    def command_line(self, mako_path = None):
+    def command_line(self, mako_path=None):
         """
         genetate the command line for the node (and its childres)
 
@@ -355,7 +356,7 @@ class InputParameter(XMLParam):
         # We use kwargs instead of the usual locals(), so manually copy the
         # name to kwargs
         if name is not None:
-            kwargs = dict([("name", name)] + list(kwargs.items()) )
+            kwargs = dict([("name", name)] + list(kwargs.items()))
 
         # Handle positional parameters
         if "positional" in kwargs and kwargs["positional"]:
@@ -420,7 +421,7 @@ class InputParameter(XMLParam):
             if len(parent_identifiers) > 0:
                 parent_identifiers.append("")
             path = ".".join(parent_identifiers)
-        return "$"+ path + self.mako_identifier
+        return "$" + path + self.mako_identifier
 
     def flag(self):
         flag = "-" * self.num_dashes
@@ -492,7 +493,7 @@ class Conditional(InputParameter):
         for c in self.children[1:]:
             if len(c.children) == 0:
                 continue
-            lines.append('#if str(%s) == "%s"' %(self.children[0].mako_name(mako_path), c.value))
+            lines.append('#if str(%s) == "%s"' % (self.children[0].mako_name(mako_path), c.value))
             lines.append(c.cli())
             lines.append('#end if')
         return "\n".join(lines)
@@ -847,6 +848,7 @@ class OutputCollection(XMLParam):
             lines.append(child.command_line())
         return "\n".join(lines)
 
+
 class DiscoverDatasets(XMLParam):
     name = "discover_datasets"
 
@@ -937,7 +939,6 @@ class TestOutputCollection(XMLParam):
     def command_line_after(self):
         return "</output_collection>"
 
-
     def command_line_actual(self, mako_path):
         lines = []
         for child in self.children:
@@ -964,7 +965,7 @@ class TestRepeat(XMLParam):
 
     def acceptable_child(self, child):
         return issubclass(type(child), TestParam) \
-            or  issubclass(type(child), TestOutput) \
+            or issubclass(type(child), TestOutput) \
             or issubclass(type(child), TestOutputCollection)
 
     def command_line_before(self, mako_path):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -336,11 +336,9 @@ class Inputs(XMLParam):
         super(Inputs, self).__init__(**params)
 
     def acceptable_child(self, child):
-        return isinstance(child, InputParameter) \
-            or issubclass(type(child), InputParameter) \
+        return issubclass(type(child), InputParameter) \
             or issubclass(type(child), Expand) \
-            or issubclass(type(child), ExpandIO) \
-            or issubclass(type(child), Param)
+            or issubclass(type(child), ExpandIO)
 
 
 class InputParameter(XMLParam):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -946,7 +946,7 @@ class TestOutputCollection(XMLParam):
 
 
 class TestRepeat(XMLParam):
-    name = "test_repeat"
+    name = "repeat"
 
     def __init__(
         self,

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -459,9 +459,8 @@ class Repeat(InputParameter):
         return "#end for"
 
     def acceptable_child(self, child):
-        return issubclass(type(child), Param) \
-            or isinstance(child, Expand) \
-            or isinstance(child, ExpandIO)
+        return issubclass(type(child), InputParameter) \
+            or isinstance(child, Expand)
 
     def command_line_actual(self, mako_path):
         lines = []

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -842,10 +842,10 @@ class OutputCollection(XMLParam):
         return "</output_collection>"
 
     def command_line_actual(self, mako_path):
-            lines = []
-            for child in self.children:
-                lines.append(child.command_line())
-            return "\n".join(lines)
+        lines = []
+        for child in self.children:
+            lines.append(child.command_line())
+        return "\n".join(lines)
 
 class DiscoverDatasets(XMLParam):
     name = "discover_datasets"
@@ -938,7 +938,7 @@ class TestOutputCollection(XMLParam):
         return "</output_collection>"
 
 
-def command_line_actual(self, mako_path):
+    def command_line_actual(self, mako_path):
         lines = []
         for child in self.children:
             lines.append(child.command_line())

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -336,9 +336,11 @@ class Inputs(XMLParam):
         super(Inputs, self).__init__(**params)
 
     def acceptable_child(self, child):
-        return issubclass(type(child), InputParameter) \
+        return isinstance(child, InputParameter) \
+            or issubclass(type(child), InputParameter) \
             or issubclass(type(child), Expand) \
-            or issubclass(type(child), ExpandIO)
+            or issubclass(type(child), ExpandIO) \
+            or issubclass(type(child), Param)
 
 
 class InputParameter(XMLParam):
@@ -459,8 +461,9 @@ class Repeat(InputParameter):
         return "#end for"
 
     def acceptable_child(self, child):
-        return issubclass(type(child), InputParameter) \
-            or isinstance(child, Expand)
+        return issubclass(type(child), Param) \
+            or isinstance(child, Expand) \
+            or isinstance(child, ExpandIO)
 
     def command_line_actual(self, mako_path):
         lines = []

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -835,8 +835,17 @@ class OutputCollection(XMLParam):
     def acceptable_child(self, child):
         return isinstance(child, OutputData) or isinstance(child, OutputFilter) or isinstance(child, DiscoverDatasets)
 
-    def command_line(self, mako_path):
-        return "## TODO CLI for OutputCollection %s" % self.name
+    def command_line_before(self, mako_path):
+        return "<output_collection name = '%s'>" % self.name
+
+    def command_line_after(self):
+        return "</output_collection>"
+
+    def command_line_actual(self, mako_path):
+            lines = []
+            for child in self.children:
+                lines.append(child.command_line())
+            return "\n".join(lines)
 
 class DiscoverDatasets(XMLParam):
     name = "discover_datasets"
@@ -894,6 +903,14 @@ class TestOutput(XMLParam):
         super(TestOutput, self).__init__(**params)
 
 
+class TestOCElement(XMLParam):
+    name = "element"
+
+    def __init__(self, name=None, file=None, ftype=None, **kwargs):
+        params = Util.clean_kwargs(locals().copy())
+        super(TestOCElement, self).__init__(**params)
+
+
 class TestOutputCollection(XMLParam):
     name = "output_collection"
 
@@ -911,18 +928,25 @@ class TestOutputCollection(XMLParam):
         params = Util.clean_kwargs(locals().copy())
         super(TestOutputCollection, self).__init__(**params)
 
+    def acceptable_child(self, child):
+        return isinstance(child, TestOCElement)
+
     def command_line_before(self, mako_path):
         return "<output_collection name = '%s'>" % self.name
 
     def command_line_after(self):
         return "</output_collection>"
 
-    def command_line_actual(self, mako_path):
 
-        return ""
+def command_line_actual(self, mako_path):
+        lines = []
+        for child in self.children:
+            lines.append(child.command_line())
+        return "\n".join(lines)
+
 
 class TestRepeat(XMLParam):
-    name = "repeat"
+    name = "test_repeat"
 
     def __init__(
         self,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst") as fh:
 
 setup(
     name="galaxyxml",
-    version="0.4.13",
+    version="0.4.14",
     description="Galaxy XML generation library",
     author="Helena Rasche",
     author_email="hxr@hx42.org",
@@ -20,5 +20,5 @@ setup(
         "Environment :: Console",
         "License :: OSI Approved :: Apache Software License",
     ],
-    data_files = [("", ["LICENSE.TXT"])]
+    data_files=[("", ["LICENSE.TXT"])]
 )

--- a/test/import_xml.xml
+++ b/test/import_xml.xml
@@ -71,11 +71,17 @@
     <test>
       <param name="sequence" value="seq.fasta"/>
       <output file="file.gbk" name="genbank"/>
-      <output_collection name="pdf_out"></output_collection>
+      <output_collection name="pdf_out"/>
       <repeat name="test_repeat">
           <param name="repeatchild" value="foo"/>
       </repeat>
-    </test>
+      <repeat name="output_repeat">
+          <output file="outputchild" name="bar"/>
+      </repeat>
+      <repeat name="collection_repeat">
+          <output_collection name="collectionchild"/>
+      </repeat>
+      </test>
   </tests>
   <help><![CDATA[help]]></help>
   <citations>

--- a/test/import_xml.xml
+++ b/test/import_xml.xml
@@ -71,16 +71,20 @@
     <test>
       <param name="sequence" value="seq.fasta"/>
       <output file="file.gbk" name="genbank"/>
-      <output_collection name="pdf_out"/>
-      <repeat name="test_repeat">
+      <output_collection name="pdf_out">
+         <element name="apdf" file="apdf" ftype="pdf"/>
+      </output_collection>
+      <test_repeat name="testrepeat">
           <param name="repeatchild" value="foo"/>
-      </repeat>
-      <repeat name="output_repeat">
+      </test_repeat>
+      <test_repeat name="output_repeat">
           <output file="outputchild" name="bar"/>
-      </repeat>
-      <repeat name="collection_repeat">
-          <output_collection name="collectionchild"/>
-      </repeat>
+      </test_repeat>
+      <test_repeat name="collection_repeat">
+          <output_collection name="collectionchild">
+              <element name="elementary" file="efile" ftype="txt"/>
+          </output_collection>
+      </test_repeat>
       </test>
   </tests>
   <help><![CDATA[help]]></help>

--- a/test/import_xml.xml
+++ b/test/import_xml.xml
@@ -74,17 +74,17 @@
       <output_collection name="pdf_out">
          <element name="apdf" file="apdf" ftype="pdf"/>
       </output_collection>
-      <test_repeat name="testrepeat">
+      <repeat name="testrepeat">
           <param name="repeatchild" value="foo"/>
-      </test_repeat>
-      <test_repeat name="output_repeat">
+      </repeat>
+      <repeat name="output_repeat">
           <output file="outputchild" name="bar"/>
-      </test_repeat>
-      <test_repeat name="collection_repeat">
+      </repeat>
+      <repeat name="collection_repeat">
           <output_collection name="collectionchild">
               <element name="elementary" file="efile" ftype="txt"/>
           </output_collection>
-      </test_repeat>
+      </repeat>
       </test>
   </tests>
   <help><![CDATA[help]]></help>

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -203,3 +203,12 @@ class TestTestsParser(TestImport):
         # test param within repeat
         self.assertEqual(repeat[0].attrib["name"], "repeatchild")
         self.assertEqual(repeat[0].attrib["value"], "foo")
+        # test output within repeat
+        output = self.tool.tests.children[0].node[4]
+        self.assertEqual(output.attrib["name"],"output_repeat")
+        self.assertEqual(output[0].attrib["file"], "outputchild")
+        self.assertEqual(output[0].attrib["name"], "bar")
+        # test outputcollection within repeat - who knows...
+        output = self.tool.tests.children[0].node[5]
+        self.assertEqual(output.attrib["name"],"collection_repeat")
+        self.assertEqual(output[0].attrib["name"], "collectionchild")

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -199,7 +199,7 @@ class TestTestsParser(TestImport):
 
     def test_repeat(self):
         repeat = self.tool.tests.children[0].node[3]
-        self.assertEqual(repeat.attrib["name"],"test_repeat")
+        self.assertEqual(repeat.attrib["name"],"testrepeat")
         # test param within repeat
         self.assertEqual(repeat[0].attrib["name"], "repeatchild")
         self.assertEqual(repeat[0].attrib["value"], "foo")
@@ -208,7 +208,14 @@ class TestTestsParser(TestImport):
         self.assertEqual(output.attrib["name"],"output_repeat")
         self.assertEqual(output[0].attrib["file"], "outputchild")
         self.assertEqual(output[0].attrib["name"], "bar")
+
+    def test_ocr(self):
         # test outputcollection within repeat - who knows...
         output = self.tool.tests.children[0].node[5]
         self.assertEqual(output.attrib["name"],"collection_repeat")
-        self.assertEqual(output[0].attrib["name"], "collectionchild")
+        collection = output[0]
+        self.assertEqual(collection.attrib["name"], "collectionchild")
+        element = collection[0]
+        self.assertEqual(element.attrib["name"], "elementary")
+        self.assertEqual(element.attrib["file"], "efile")
+        self.assertEqual(element.attrib["ftype"], "txt")


### PR DESCRIPTION
Apropos #34 and #32

Got the CL for outputcollections working.
Children are new TestOCElements as mentioned in #34

Disambiguated test_repeat from repeat - not sure if that is needed but it seems clearer to me for them to have different names.

The following is a section of test XML now correctly parsed for elements in collections and collections in repeats - why anyone would want those I'm not sure but if they're ever needed, we are all set - at least nose thinks we are...

 
```
 <tests>
    <test>
      <param name="sequence" value="seq.fasta"/>
      <output file="file.gbk" name="genbank"/>
      <output_collection name="pdf_out">
         <element name="apdf" file="apdf" ftype="pdf"/>
      </output_collection>
      <repeat name="testrepeat">
          <param name="repeatchild" value="foo"/>
      </repeat>
      <repeat name="output_repeat">
          <output file="outputchild" name="bar"/>
      </repeat>
      <repeat name="collection_repeat">
          <output_collection name="collectionchild">
              <element name="elementary" file="efile" ftype="txt"/>
          </output_collection>
      </repeat>
    </test>
 </tests>
```