### PR TITLE
Extract GHA From #37

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Release (by Tag Push)
+
+'on':
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  deploy:
+    name: Deploy
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}
+    - uses: casperdcl/deploy-pypi@v2
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}
+        build: --sdist --wheel --outdir dist .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,7 @@ jobs:
       run: flake8 --ignore=C901,W503
     - name: Black
       uses: psf/black@23.3.0
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -45,8 +46,9 @@ jobs:
       run: python -m pip install .
     - name: install packages for testing
       run: pip install nose xmldiff
-    - name: run nosetests
-      run: nosetests --with-coverage --cover-package=galaxyxml
+      # TODO: replace with tox tests from #38
+      #- name: run nosetests
+      #  run: nosetests --with-coverage --cover-package=galaxyxml
 
     - name: Run smoke test on example
       run: |
@@ -54,7 +56,6 @@ jobs:
         xmldiff tmp.xml examples/tool.xml
         python examples/example_macros.py > tmp.xml
         xmldiff tmp.xml examples/example_macros.xml
-
 
   deploy:
     name: Deploy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: Test Pull Request
 
-on: [push,pull_request]
+on: [pull_request]
 
 jobs:
   lint:
@@ -56,28 +56,3 @@ jobs:
         xmldiff tmp.xml examples/tool.xml
         python examples/example_macros.py > tmp.xml
         xmldiff tmp.xml examples/example_macros.xml
-
-  deploy:
-    name: Deploy
-    needs: [lint, test]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.7']
-    steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache .cache/pip
-      uses: actions/cache@v3
-      id: cache-pip
-      with:
-        path: ~/.cache/pip
-        key: pip_cache_py_${{ matrix.python-version }}
-    - uses: casperdcl/deploy-pypi@v2
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}
-        build: --sdist --wheel --outdir dist .
-        # only upload if a tag is pushed (otherwise just build & check)
-        upload: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,82 @@
+name: Test Pull Request
+
+on: [push,pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8']
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}
+    - name: Install package
+      run: pip install -r requirements.txt black==23.3 flake8==6.0
+    - name: Flake8
+      run: flake8 --ignore=C901,W503
+    - name: Black
+      uses: psf/black@23.3.0
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8']
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}
+    - name: install package
+      run: python -m pip install .
+    - name: install packages for testing
+      run: pip install nose xmldiff
+    - name: run nosetests
+      run: nosetests --with-coverage --cover-package=galaxyxml
+
+    - name: Run smoke test on example
+      run: |
+        python examples/example.py > tmp.xml
+        xmldiff tmp.xml examples/tool.xml
+        python examples/example_macros.py > tmp.xml
+        xmldiff tmp.xml examples/example_macros.xml
+
+
+  deploy:
+    name: Deploy
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache .cache/pip
+      uses: actions/cache@v3
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: pip_cache_py_${{ matrix.python-version }}
+    - uses: casperdcl/deploy-pypi@v2
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}
+        build: --sdist --wheel --outdir dist .
+        # only upload if a tag is pushed (otherwise just build & check)
+        upload: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,6 @@ jobs:
     - name: Run smoke test on example
       run: |
         python examples/example.py > tmp.xml
-        xmldiff tmp.xml examples/tool.xml
+        xmldiff --check tmp.xml examples/tool.xml
         python examples/example_macros.py > tmp.xml
-        xmldiff tmp.xml examples/example_macros.xml
+        xmldiff --check tmp.xml examples/example_macros.xml

--- a/examples/example.py
+++ b/examples/example.py
@@ -88,7 +88,7 @@ param.space_between_arg = " "
 outputs.append(param)
 # Collection
 collection = gxtp.OutputCollection("supercollection", label="a small label")
-discover = gxtp.DiscoverDatasets("(?P&lt;designation&gt;.+)\.pdf.fasta", format="fasta")
+discover = gxtp.DiscoverDatasets("(?P&lt;designation&gt;.+).pdf.fasta", format="fasta")
 collection.append(discover)
 outputs.append(collection)
 
@@ -111,7 +111,7 @@ param = gxtp.TestParam("repeatchild", value="foo")
 rep_out.append(param)
 test_a.append(rep_out)
 test_coll = gxtp.TestOutputCollection(name="pdf_out")
-test_elem = gxtp.TestOCElement(name="apdf",file="apdf",ftype="pdf")
+test_elem = gxtp.TestOCElement(name="apdf", file="apdf", ftype="pdf")
 test_coll.append(test_elem)
 test_a.append(test_coll)
 rep_out = gxtp.TestRepeat(name="output_repeat")

--- a/examples/example_macros.py
+++ b/examples/example_macros.py
@@ -3,7 +3,7 @@ import galaxyxml.tool as gxt
 import galaxyxml.tool.parameters as gxtp
 
 # examplify the use of MacrosTool
-# 
+#
 
 tool = gxt.MacrosTool(
     name="aragorn",
@@ -57,6 +57,7 @@ param_min.command_line_override = "-i$int_min,$int_max"
 param_max.command_line_override = ""
 param_min.space_between_arg = " "
 param_max.space_between_arg = " "
+
 inputs.append(param_min)
 inputs.append(param_max)
 inputs.append(posint)
@@ -84,7 +85,7 @@ param.space_between_arg = " "
 outputs.append(param)
 # Collection
 collection = gxtp.OutputCollection("supercollection", label="a small label")
-discover = gxtp.DiscoverDatasets("(?P&lt;designation&gt;.+)\.pdf.fasta", format="fasta")
+discover = gxtp.DiscoverDatasets("(?P&lt;designation&gt;.+).pdf.fasta", format="fasta")
 collection.append(discover)
 outputs.append(collection)
 

--- a/test/unit_test_import_xml.py
+++ b/test/unit_test_import_xml.py
@@ -19,6 +19,7 @@ class TestStdios(TestImport):
         self.assertEqual(std.attrib["level"], "fatal")
         self.assertEqual(std.attrib["range"], "1:")
 
+
 class TestOverrides(TestImport):
     def test_override(self):
         co = "bash foo.sh > output1"
@@ -199,20 +200,20 @@ class TestTestsParser(TestImport):
 
     def test_repeat(self):
         repeat = self.tool.tests.children[0].node[3]
-        self.assertEqual(repeat.attrib["name"],"testrepeat")
+        self.assertEqual(repeat.attrib["name"], "testrepeat")
         # test param within repeat
         self.assertEqual(repeat[0].attrib["name"], "repeatchild")
         self.assertEqual(repeat[0].attrib["value"], "foo")
         # test output within repeat
         output = self.tool.tests.children[0].node[4]
-        self.assertEqual(output.attrib["name"],"output_repeat")
+        self.assertEqual(output.attrib["name"], "output_repeat")
         self.assertEqual(output[0].attrib["file"], "outputchild")
         self.assertEqual(output[0].attrib["name"], "bar")
 
     def test_ocr(self):
         # test outputcollection within repeat - who knows...
         output = self.tool.tests.children[0].node[5]
-        self.assertEqual(output.attrib["name"],"collection_repeat")
+        self.assertEqual(output.attrib["name"], "collection_repeat")
         collection = output[0]
         self.assertEqual(collection.attrib["name"], "collectionchild")
         element = collection[0]


### PR DESCRIPTION
We clearly needed this sooner.

I am morally opposed to `isort` linting, if there is something that will automatically apply the `isort`, then awesome, let's add it to the `reformat` make target, but the linting without an automatic fix I object to.