### PR TITLE
fix node_name atrib of Command

### DIFF
--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -83,7 +83,7 @@ class XMLParam(object):
 
 
 class Command(XMLParam):
-    name = "command"
+    node_name = "command"
 
     def __init__(self, detect_errors=None, **kwargs):
         params = Util.clean_kwargs(locals().copy())


### PR DESCRIPTION
otherwise the generated xml has <node> instead of <command>