### PR TITLE
Standard of empty_field validator is now without text

### DIFF
--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -862,7 +862,8 @@ class ValidatorParam(XMLParam):
         params = Util.clean_kwargs(locals().copy())
         del params["text"]
         super(ValidatorParam, self).__init__(**params)
-        self.node.text = etree.CDATA(str(text))
+        if text: 
+            self.node.text = etree.CDATA(str(text))
 
 
 class Outputs(XMLParam):

--- a/galaxyxml/tool/parameters/__init__.py
+++ b/galaxyxml/tool/parameters/__init__.py
@@ -862,7 +862,7 @@ class ValidatorParam(XMLParam):
         params = Util.clean_kwargs(locals().copy())
         del params["text"]
         super(ValidatorParam, self).__init__(**params)
-        if text: 
+        if text:
             self.node.text = etree.CDATA(str(text))
 
 


### PR DESCRIPTION
With this small change the empty_field validator wont write the CDATA tag as text to the validator.